### PR TITLE
Add basic github workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CI: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Run npm install
+      run: |
+        npm install
+
+    - name: Run linting
+      run: |
+        npm run eslint
+
+    - name: Run formatting checks
+      run: |
+        npm run prettier-check
+
+    - name: Run tests
+      run: |
+        npm run test
+
+    - name: Run coverage
+      run: |
+        npm run coverage
+


### PR DESCRIPTION
This addresses https://github.com/CesiumGS/3d-tiles-tools/issues/19 . But there recently have been reports about TypeScript compilation failing in the validator at https://github.com/CesiumGS/3d-tiles-validator/issues/272 , and since this part of the code was _moved_ here (from the validator), the build will likely fail here as well. I could not (yet) reproduce the build failure locally, but will try to investigate it ASAP.

