### PR TITLE
Fix zip comparison

### DIFF
--- a/specs/SpecHelpers.ts
+++ b/specs/SpecHelpers.ts
@@ -275,13 +275,13 @@ export class SpecHelpers {
     }
 
     // The entries are not JSON. Just compare the buffer data.
-    if (valueA.length != valueB.length) {
-      return `Value ${key} has ${valueA.length} bytes in ${nameA} and ${valueB.length} bytes in ${nameB}`;
+    if (unzippedValueA.length != unzippedValueB.length) {
+      return `Value ${key} has ${unzippedValueA.length} bytes in ${nameA} and ${unzippedValueB.length} bytes in ${nameB}`;
     }
-    const n = valueA.length;
+    const n = unzippedValueA.length;
     for (let j = 0; j < n; j++) {
-      if (valueA[j] != valueB[j]) {
-        return `Value ${key} has ${valueA[j]} at index ${j} in ${nameA} but ${valueB[j]} in ${nameB}`;
+      if (unzippedValueA[j] != unzippedValueB[j]) {
+        return `Value ${key} has ${unzippedValueA[j]} at index ${j} in ${nameA} but ${unzippedValueB[j]} in ${nameB}`;
       }
     }
 


### PR DESCRIPTION
As part of the fix for https://github.com/CesiumGS/3d-tiles-tools/issues/22 , I had added some tests for the "roundtrips" between zipped and unzipped data. Comparing data in this "verbatim" form can be brittle (e.g. due to certain `CR/LF` issues for text files and such). But for ZIP data, there's another caveat: The GZIP header contains a byte that indicates the operating system. Ouch.

This PR changes the comparison to _unpack_ any zipped data before comparing it, to get rid of the GZIP header differences that are not relevant.
