### PR TITLE
Allow passing upgrade options to `gltf-pipeline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,23 @@ Upgrade a tileset to the latest 3D Tiles version.
 ```
 npx 3d-tiles-tools upgrade -i ./specs/data/TilesetOfTilesets/tileset.json -o ./output/upgraded
 ```
+
+Additional command line options:
+
+| Flag | Description | Required |
+| ---- | ----------- | -------- |
+|`--options`|All arguments past this flag are consumed by gltf-pipeline.| No |
+
 The exact behavior of the upgrade operation is not yet specified. But when B3DM- and I3DM tile content in the input tileset uses glTF 1.0 assets, then the upgrade step will try to upgrade these assets to glTF 2.0.
+
+> Implementation Note:
+>
+> The upgrade command also tries to upgrade glTF assets that are embedded into B3DM or I3DM tiles. Internally, this is achieved by processing the GLB data with [`gltf-pipeline`](https://github.com/CesiumGS/gltf-pipeline/). This upgrade will include the attempt to convert glTF 1.0 assets into glTF 2.0 assets. And it will include the attempt to convert materials that are given with the `KHR_technique_webgl` extension into PBR materials. Options that are given after the `--options` parameter are passed to `gltf-pipeline`. These options may include the names of uniform variables that should indicate whether a certain texture is used as the "base color" texture of a PRB material. For example, when a tileset contains B3DM or I3DM data that contains GLB with the `KHR_technique_webgl` extension where the uniform names `u_diff_tex` and `u_diffuse` indicate that a texture should be a base color texture, then the command line
+> ```
+> npx 3d-tiles-tools upgrade -i ./input/tileset.json -o ./output/tileset.json --options --baseColorTextureNames u_diff_tex --baseColorTextureNames u_diffuse
+> ```
+> can be used.
+
 
 #### convert
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "archiver": "^5.3.1",
     "better-sqlite3": "^8.0.1",
     "cesium": "^1.103.0",
-    "gltf-pipeline": "^4.0.1",
+    "gltf-pipeline": "^4.1.0",
     "minimist": "^1.2.7",
     "node-stream-zip": "^1.15.0",
     "seedrandom": "^3.0.5",

--- a/specs/TilesetUpgraderSpec.ts
+++ b/specs/TilesetUpgraderSpec.ts
@@ -8,6 +8,7 @@ import { Tileset } from "../src/structure/Tileset";
 // each modification (upgrade step) to the console.
 // This flag can be used to disable the log messages:
 const quiet = true;
+const gltfUpgradeOptions = undefined;
 
 // A unit bounding box, used for all tiles
 const unitBoundingBox = {
@@ -65,7 +66,7 @@ const inputTilesetJsonString = JSON.stringify(inputTilesetJsonRaw);
 
 describe("TilesetUpgrader", function () {
   it("upgrades the version number to 1.1", async function () {
-    const tilesetUpgrader = new TilesetUpgrader(quiet);
+    const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
 
     const tileset = JSON.parse(inputTilesetJsonString) as Tileset;
     await tilesetUpgrader.upgradeTileset(tileset);
@@ -73,7 +74,7 @@ describe("TilesetUpgrader", function () {
   });
 
   it("upgrades the content.url to content.uri", async function () {
-    const tilesetUpgrader = new TilesetUpgrader(quiet);
+    const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
 
     const tileset = JSON.parse(inputTilesetJsonString) as Tileset;
     await tilesetUpgrader.upgradeTileset(tileset);
@@ -84,7 +85,7 @@ describe("TilesetUpgrader", function () {
   });
 
   it("upgrades the refine values to be in uppercase", async function () {
-    const tilesetUpgrader = new TilesetUpgrader(quiet);
+    const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
 
     const tileset = JSON.parse(inputTilesetJsonString) as Tileset;
     await tilesetUpgrader.upgradeTileset(tileset);
@@ -95,7 +96,7 @@ describe("TilesetUpgrader", function () {
   });
 
   it("removes the unnecessary extension declaration for 3DTILES_content_gltf", async function () {
-    const tilesetUpgrader = new TilesetUpgrader(quiet);
+    const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
 
     const tileset = JSON.parse(inputTilesetJsonString) as Tileset;
     await tilesetUpgrader.upgradeTileset(tileset);

--- a/src/ToolsMain.ts
+++ b/src/ToolsMain.ts
@@ -43,7 +43,10 @@ export class ToolsMain {
     const inputBuffer = fs.readFileSync(input);
     const inputTileData = TileFormats.readTileData(inputBuffer);
     const outputBuffer = inputTileData.payload;
-    const upgradedOutputBuffer = await GltfUtilities.upgradeGlb(outputBuffer);
+    const upgradedOutputBuffer = await GltfUtilities.upgradeGlb(
+      outputBuffer,
+      undefined
+    );
     fs.writeFileSync(output, upgradedOutputBuffer);
   }
   static async i3dmToGlb(input: string, output: string, force: boolean) {
@@ -68,7 +71,10 @@ export class ToolsMain {
       const glbPath = glbPaths[i];
       ToolsMain.ensureCanWrite(glbPath, force);
       const glbBuffer = glbBuffers[i];
-      const upgradedOutputBuffer = await GltfUtilities.upgradeGlb(glbBuffer);
+      const upgradedOutputBuffer = await GltfUtilities.upgradeGlb(
+        glbBuffer,
+        undefined
+      );
       fs.writeFileSync(glbPath, upgradedOutputBuffer);
     }
   }
@@ -354,9 +360,14 @@ export class ToolsMain {
     await Tilesets.combine(input, output, force);
   }
 
-  static async upgrade(input: string, output: string, force: boolean) {
+  static async upgrade(
+    input: string,
+    output: string,
+    force: boolean,
+    gltfUpgradeOptions: any
+  ) {
     ToolsMain.ensureCanWrite(output, force);
-    await Tilesets.upgrade(input, output, force);
+    await Tilesets.upgrade(input, output, force, gltfUpgradeOptions);
   }
 
   static async merge(inputs: string[], output: string, force: boolean) {

--- a/src/contentProcessing/GtlfUtilities.ts
+++ b/src/contentProcessing/GtlfUtilities.ts
@@ -20,10 +20,12 @@ export class GltfUtilities {
    * subset of glTF 1.0 binary data to glTF 2.0.
    *
    * @param glbBuffer - The buffer containing the GLB
+   * @param options - Options for the upgrade that are passed to
+   * `gltf-pipeline`
    * @returns A promise that resolves with the upgraded GLB.
    */
-  static async upgradeGlb(glbBuffer: Buffer): Promise<Buffer> {
-    const result = await GltfPipeline.processGlb(glbBuffer);
+  static async upgradeGlb(glbBuffer: Buffer, options: any): Promise<Buffer> {
+    const result = await GltfPipeline.processGlb(glbBuffer, options);
     return result.glb;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -290,7 +290,7 @@ async function runCommand(command: string, toolArgs: any, optionArgs: any) {
   } else if (command === "combine") {
     await ToolsMain.combine(input, output, force);
   } else if (command === "upgrade") {
-    await ToolsMain.upgrade(input, output, force);
+    await ToolsMain.upgrade(input, output, force, parsedOptionArgs);
   } else if (command === "merge") {
     await ToolsMain.merge(inputs, output, force);
   } else if (command === "pipeline") {

--- a/src/pipelines/TilesetStageExecutor.ts
+++ b/src/pipelines/TilesetStageExecutor.ts
@@ -91,7 +91,8 @@ export class TilesetStageExecutor {
       );
     } else if (tilesetStage.name === TilesetStages.TILESET_STAGE_UPGRADE) {
       const quiet = false;
-      const tilesetUpgrader = new TilesetUpgrader(quiet);
+      const gltfUpgradeOptions = undefined;
+      const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
       await tilesetUpgrader.upgrade(currentInput, currentOutput, overwrite);
     } else if (tilesetStage.name === TilesetStages.TILESET_STAGE_COMBINE) {
       const externalTilesetDetector = ContentDataTypeChecks.createIncludedCheck(

--- a/src/tilesetProcessing/TilesetUpgrader.ts
+++ b/src/tilesetProcessing/TilesetUpgrader.ts
@@ -68,17 +68,27 @@ export class TilesetUpgrader {
   private readonly upgradeOptions: UpgradeOptions;
 
   /**
+   * The options that may be passed to `gltf-pipeline` when
+   * GLB data in B3DM or I3DM is supposed to be upgraded.
+   */
+  private readonly gltfUpgradeOptions: UpgradeOptions;
+
+  /**
    * Creates a new instance
    *
    * @param quiet - Whether log messages should be omitted
+   * @param gltfUpgradeOptions - Options that may be passed
+   * to `gltf-pipeline` when GLB data in B3DM or I3DM is
+   * supposed to be upgraded.
    */
-  constructor(quiet?: boolean) {
+  constructor(quiet: boolean, gltfUpgradeOptions: any) {
     if (quiet !== true) {
       this.logCallback = (message: any) => console.log(message);
     } else {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
       this.logCallback = (message: any) => {};
     }
+    this.gltfUpgradeOptions = gltfUpgradeOptions;
 
     // By default, ALL options are enabled
     this.upgradeOptions = {
@@ -347,14 +357,20 @@ export class TilesetUpgrader {
     if (type === ContentDataTypes.CONTENT_TYPE_B3DM) {
       if (this.upgradeOptions.upgradeB3dmGltf1ToGltf2) {
         this.logCallback(`  Upgrading GLB in ${key}`);
-        value = await TilesetUpgrader.upgradeB3dmGltf1ToGltf2(value);
+        value = await TilesetUpgrader.upgradeB3dmGltf1ToGltf2(
+          value,
+          this.gltfUpgradeOptions
+        );
       } else {
         this.logCallback(`  Not upgrading GLB in ${key} (disabled via option)`);
       }
     } else if (type === ContentDataTypes.CONTENT_TYPE_I3DM) {
       if (this.upgradeOptions.upgradeI3dmGltf1ToGltf2) {
         this.logCallback(`  Upgrading GLB in ${key}`);
-        value = await TilesetUpgrader.upgradeI3dmGltf1ToGltf2(value);
+        value = await TilesetUpgrader.upgradeI3dmGltf1ToGltf2(
+          value,
+          this.gltfUpgradeOptions
+        );
       } else {
         this.logCallback(`  Not upgrading GLB in ${key} (disabled via option)`);
       }
@@ -379,14 +395,17 @@ export class TilesetUpgrader {
    * result, and return it.
    *
    * @param inputBuffer - The input buffer
+   * @param options - Options that will be passed to the
+   * `gltf-pipeline` when the GLB is processed.
    * @returns The upgraded buffer
    */
   private static async upgradeB3dmGltf1ToGltf2(
-    inputBuffer: Buffer
+    inputBuffer: Buffer,
+    options: any
   ): Promise<Buffer> {
     const inputTileData = TileFormats.readTileData(inputBuffer);
     const inputGlb = inputTileData.payload;
-    const outputGlb = await GltfUtilities.upgradeGlb(inputGlb);
+    const outputGlb = await GltfUtilities.upgradeGlb(inputGlb, options);
     const outputTileData = TileFormats.createB3dmTileDataFromGlb(
       outputGlb,
       inputTileData.featureTable.json,
@@ -404,14 +423,17 @@ export class TilesetUpgrader {
    * result, and return it.
    *
    * @param inputBuffer - The input buffer
+   * @param options - Options that will be passed to the
+   * `gltf-pipeline` when the GLB is processed.
    * @returns The upgraded buffer
    */
   private static async upgradeI3dmGltf1ToGltf2(
-    inputBuffer: Buffer
+    inputBuffer: Buffer,
+    options: any
   ): Promise<Buffer> {
     const inputTileData = TileFormats.readTileData(inputBuffer);
     const inputGlb = inputTileData.payload;
-    const outputGlb = await GltfUtilities.upgradeGlb(inputGlb);
+    const outputGlb = await GltfUtilities.upgradeGlb(inputGlb, options);
     const outputTileData = TileFormats.createI3dmTileDataFromGlb(
       outputGlb,
       inputTileData.featureTable.json,

--- a/src/tilesets/Tilesets.ts
+++ b/src/tilesets/Tilesets.ts
@@ -70,6 +70,9 @@ export class Tilesets {
    * @param tilesetTargetName - The tileset target name
    * @param overwrite Whether the target should be overwritten if
    * it already exists
+   * @param gltfUpgradeOptions - Options that may be passed
+   * to `gltf-pipeline` when GLB data in B3DM or I3DM is
+   * supposed to be upgraded.
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed,
    * or when the output already exists and `overwrite` was `false`.
@@ -77,9 +80,11 @@ export class Tilesets {
   static async upgrade(
     tilesetSourceName: string,
     tilesetTargetName: string,
-    overwrite: boolean
+    overwrite: boolean,
+    gltfUpgradeOptions: any
   ) {
-    const tilesetUpgrader = new TilesetUpgrader();
+    const quiet = false;
+    const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
     tilesetUpgrader.upgrade(tilesetSourceName, tilesetTargetName, overwrite);
   }
 
@@ -90,7 +95,9 @@ export class Tilesets {
    * @throws TilesetError When the input could not be processed
    */
   static async upgradeTileset(tileset: Tileset) {
-    const tilesetUpgrader = new TilesetUpgrader();
+    const quiet = false;
+    const gltfUpgradeOptions = undefined;
+    const tilesetUpgrader = new TilesetUpgrader(quiet, gltfUpgradeOptions);
     await tilesetUpgrader.upgradeTileset(tileset);
   }
 


### PR DESCRIPTION
Update to the latest version of `gltf-pipeline`, and allow passing command line options to the `upgrade` command that will be forwarded to `gltf-pipeline`.

An example use case of this is described as an "Implementation Note" in the README: The upgrade command calls the `gltf-pipeline` to upgrade GLB that use the `KHR_techniqe_webgl` extension, into GLBs that no longer use this extension. This is necessary for certain viewers and renderers (including the `cesium-native` based ones) which do not support the `KHR_techniques_webgl` extension.

`gltf-pipeline` replaces the extension by generating appropriate PBR materials. The the uniform names that indicate that textures should become base color textures are defined as the [`defaultBaseColorTextureNames` in `gltf-pipeline`](https://github.com/CesiumGS/gltf-pipeline/blob/1d6a4c9516f94d9f50c2f20a70c1804947f115f0/lib/updateVersion.js#L1010). When different uniform names have to be used, they can be passed to the upgrade command after the `--options`, as `--baseColorTextureNames`.








