### PR TITLE
Create a "content" object for single contents.

### DIFF
--- a/specs/BasicTilesetProcessorSpec.ts
+++ b/specs/BasicTilesetProcessorSpec.ts
@@ -13,6 +13,8 @@ import { Tile } from "../src/structure/Tile";
 
 import { TraversedTile } from "../src/traversal/TraversedTile";
 
+import { TilesetEntry } from "../src/tilesetData/TilesetEntry";
+
 const basicInput = "./specs/data/tilesetProcessing/basicProcessing";
 const basicOutput = "./specs/data/output/tilesetProcessing/basicProcessing";
 const quiet = true;
@@ -39,15 +41,14 @@ describe("BasicTilesetProcessor on explicit input", function () {
     });
     await tilesetProcessor.end();
 
-    // NOTE: The order is actually not specified.
-    // This should be sorted lexographically for
-    // the comparison...
     const expectedContentUris = [
       ["tileA.b3dm"],
       ["tileB.b3dm", "sub/tileB.b3dm"],
       ["tileC.b3dm"],
       ["tileA.b3dm"],
     ];
+    SpecHelpers.sortStringsLexicographically(actualContentUris);
+    SpecHelpers.sortStringsLexicographically(expectedContentUris);
     expect(actualContentUris).toEqual(expectedContentUris);
   });
 
@@ -63,15 +64,14 @@ describe("BasicTilesetProcessor on explicit input", function () {
     });
     await tilesetProcessor.end();
 
-    // NOTE: The order is actually not specified.
-    // This should be sorted lexographically for
-    // the comparison...
     const expectedContentUris = [
       ["tileA.b3dm"],
       ["tileB.b3dm", "sub/tileB.b3dm"],
       ["tileC.b3dm"],
       ["tileA.b3dm"],
     ];
+    SpecHelpers.sortStringsLexicographically(actualContentUris);
+    SpecHelpers.sortStringsLexicographically(expectedContentUris);
     expect(actualContentUris).toEqual(expectedContentUris);
   });
 
@@ -94,6 +94,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
     ];
     const actualProcessedKeys = specEntryProcessor.processedKeys;
     actualProcessedKeys.sort();
+    expectedProcessedKeys.sort();
     expect(actualProcessedKeys).toEqual(expectedProcessedKeys);
 
     // Expect the names of content files to have been modified
@@ -107,6 +108,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
     ];
     const actualOutputFiles = SpecHelpers.collectRelativeFileNames(basicOutput);
     actualOutputFiles.sort();
+    expectedOutputFiles.sort();
     expect(actualOutputFiles).toEqual(expectedOutputFiles);
   });
 
@@ -129,7 +131,6 @@ describe("BasicTilesetProcessor on explicit input", function () {
     const actualContentUris = await SpecHelpers.collectExplicitContentUris(
       tileset.root
     );
-    actualContentUris.sort();
 
     const expectedContentUris = [
       "PROCESSED_sub/tileB.b3dm",
@@ -138,6 +139,99 @@ describe("BasicTilesetProcessor on explicit input", function () {
       "PROCESSED_tileB.b3dm",
       "PROCESSED_tileC.b3dm",
     ];
+    actualContentUris.sort();
+    expectedContentUris.sort();
     expect(actualContentUris).toEqual(expectedContentUris);
+  });
+
+  it("processTileContentEntries updates the tile contents", async function () {
+    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    await tilesetProcessor.begin(basicInput, basicOutput, overwrite);
+
+    const inputTilesetJsonBuffer = fs.readFileSync(
+      Paths.join(basicInput, "tileset.json")
+    );
+    const inputTileset = JSON.parse(inputTilesetJsonBuffer.toString());
+
+    // Initially, child 0 contains multiple contents
+    // (namely, "tileB.b3dm" and "sub/tileB.b3dm")
+    expect(inputTileset.root.children[0].content).toBeUndefined();
+    expect(inputTileset.root.children[0].contents).toBeDefined();
+
+    // Initially, child 1 contains a single content
+    // (namely, "tileC.b3dm")
+    expect(inputTileset.root.children[1].content).toBeDefined();
+    expect(inputTileset.root.children[1].contents).toBeUndefined();
+
+    // Define an entry processor that removes
+    // - one of the multiple contents of child 0
+    // - the only content of child 1
+    const entryProcessor = async (
+      sourceEntry: TilesetEntry,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      type: string | undefined
+    ) => {
+      if (sourceEntry.key.startsWith("sub/")) {
+        return undefined;
+      }
+      if (sourceEntry.key.startsWith("tileC")) {
+        return undefined;
+      }
+      return {
+        key: sourceEntry.key,
+        value: sourceEntry.value,
+      };
+    };
+    await tilesetProcessor.processTileContentEntries(
+      (uri: string) => uri,
+      entryProcessor
+    );
+    await tilesetProcessor.end();
+
+    const outputTilesetJsonBuffer = fs.readFileSync(
+      Paths.join(basicOutput, "tileset.json")
+    );
+    const outputTileset = JSON.parse(outputTilesetJsonBuffer.toString());
+
+    // After processing, child 0 only contains a single content
+    expect(outputTileset.root.children[0].content).toBeDefined();
+    expect(outputTileset.root.children[0].contents).toBeUndefined();
+
+    // After processing, child 1 contains no content or contents
+    expect(outputTileset.root.children[1].content).toBeUndefined();
+    expect(outputTileset.root.children[1].contents).toBeUndefined();
+  });
+
+  it("updateTileContent updates the tile contents", async function () {
+    const tile: Tile = {
+      content: {
+        uri: "SPEC_URI",
+      },
+      boundingVolume: {
+        box: [0.5, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.5],
+      },
+      geometricError: 1.0,
+    };
+
+    // Using an empty `contentUris` array causes `content` and
+    // `contents` to become undefined
+    const contentUris0: string[] = [];
+    BasicTilesetProcessor.updateTileContent(tile, contentUris0);
+    expect(tile.content).toBeUndefined();
+    expect(tile.contents).toBeUndefined();
+
+    // Using a single-element `contentUris` array causes `content`
+    // to be defined, but `contents` to be undefined
+    const contentUris1 = ["SPEC_URI"];
+    BasicTilesetProcessor.updateTileContent(tile, contentUris1);
+    expect(tile.content).toBeDefined();
+    expect(tile.contents).toBeUndefined();
+
+    // Using a multi-element `contentUris` array causes `content`
+    // to be undefined, but `contents` to be defined
+    const contentUris2 = ["SPEC_URI_0", "SPEC_URI_1"];
+    BasicTilesetProcessor.updateTileContent(tile, contentUris2);
+    expect(tile.content).toBeUndefined();
+    expect(tile.contents).toBeDefined();
   });
 });

--- a/specs/ImplicitTilesetProcessorSpec.ts
+++ b/specs/ImplicitTilesetProcessorSpec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import fs from "fs";
-
 import { SpecHelpers } from "./SpecHelpers";
 import { SpecEntryProcessor } from "./SpecEntryProcessor";
 

--- a/specs/ImplicitTilingsSpec.ts
+++ b/specs/ImplicitTilingsSpec.ts
@@ -36,7 +36,7 @@ describe("ImplicitTilings", function () {
       ImplicitTilings.createSubtreeCoordinatesIterator(implicitTiling);
     const actualCoordinates = [...iterator].map((c) => c.toArray());
 
-    SpecHelpers.sortLexicographically(actualCoordinates);
+    SpecHelpers.sortNumbersLexicographically(actualCoordinates);
     const expectedCoordinates = [
       [0, 0, 0],
       [1, 0, 0],
@@ -60,7 +60,7 @@ describe("ImplicitTilings", function () {
       [2, 2, 3],
       [2, 3, 3],
     ];
-    SpecHelpers.sortLexicographically(expectedCoordinates);
+    SpecHelpers.sortNumbersLexicographically(expectedCoordinates);
     expect(actualCoordinates).toEqual(expectedCoordinates);
   });
 
@@ -70,7 +70,7 @@ describe("ImplicitTilings", function () {
       ImplicitTilings.createSubtreeCoordinatesIterator(implicitTiling);
     const actualCoordinates = [...iterator].map((c) => c.toArray());
 
-    SpecHelpers.sortLexicographically(actualCoordinates);
+    SpecHelpers.sortNumbersLexicographically(actualCoordinates);
     const expectedCoordinates = [
       [0, 0, 0, 0],
       [1, 0, 0, 0],
@@ -146,7 +146,7 @@ describe("ImplicitTilings", function () {
       [2, 2, 3, 3],
       [2, 3, 3, 3],
     ];
-    SpecHelpers.sortLexicographically(expectedCoordinates);
+    SpecHelpers.sortNumbersLexicographically(expectedCoordinates);
     expect(actualCoordinates).toEqual(expectedCoordinates);
   });
 

--- a/specs/SpecHelpers.ts
+++ b/specs/SpecHelpers.ts
@@ -313,7 +313,7 @@ export class SpecHelpers {
   }
 
   /**
-   * Compares two arrays lexicographically.
+   * Compares two arrays of numbers lexicographically.
    *
    * When the arrays have different lengths, then the shorter
    * one will be "padded" with elements that are smaller than
@@ -323,7 +323,7 @@ export class SpecHelpers {
    * @param b - The second array
    * @returns The result of the comparison
    */
-  private static compareLexicographically(a: number[], b: number[]) {
+  private static compareNumbersLexicographically(a: number[], b: number[]) {
     const n = Math.min(a.length, b.length);
     for (let i = 0; i < n; i++) {
       const d = a[i] - b[i];
@@ -341,7 +341,7 @@ export class SpecHelpers {
   }
 
   /**
-   * Sorts a 2D array lexicographically, in place.
+   * Sorts a 2D array of numbers lexicographically, in place.
    *
    * When two elements have different lengths, then the shorter
    * one will be "padded" with elements that are smaller than
@@ -350,8 +350,51 @@ export class SpecHelpers {
    * @param array - The array
    * @returns The array
    */
-  static sortLexicographically(array: number[][]) {
-    array.sort(SpecHelpers.compareLexicographically);
+  static sortNumbersLexicographically(array: number[][]) {
+    array.sort(SpecHelpers.compareNumbersLexicographically);
+    return array;
+  }
+
+  /**
+   * Compares two arrays of strings lexicographically.
+   *
+   * When the arrays have different lengths, then the shorter
+   * one will be "padded" with elements that are smaller than
+   * all other elements in the other array.
+   *
+   * @param a - The first array
+   * @param b - The second array
+   * @returns The result of the comparison
+   */
+  private static compareStringsLexicographically(a: string[], b: string[]) {
+    const n = Math.min(a.length, b.length);
+    for (let i = 0; i < n; i++) {
+      const d = a[i].localeCompare(b[i]);
+      if (d !== 0) {
+        return d;
+      }
+    }
+    if (a.length < b.length) {
+      return -1;
+    }
+    if (a.length > b.length) {
+      return 1;
+    }
+    return 0;
+  }
+
+  /**
+   * Sorts a 2D array of strings lexicographically, in place.
+   *
+   * When two elements have different lengths, then the shorter
+   * one will be "padded" with elements that are smaller than
+   * all other elements in the other array.
+   *
+   * @param array - The array
+   * @returns The array
+   */
+  static sortStringsLexicographically(array: string[][]) {
+    array.sort(SpecHelpers.compareStringsLexicographically);
     return array;
   }
 }

--- a/specs/TilesetDataProcessorSpec.ts
+++ b/specs/TilesetDataProcessorSpec.ts
@@ -37,6 +37,7 @@ describe("TilesetDataProcessor", function () {
     ];
     const actualProcessedKeys = specEntryProcessor.processedKeys;
     actualProcessedKeys.sort();
+    expectedProcessedKeys.sort();
     expect(actualProcessedKeys).toEqual(expectedProcessedKeys);
 
     // Expect the names of ALL files to have been modified
@@ -50,6 +51,7 @@ describe("TilesetDataProcessor", function () {
     ];
     const actualOutputFiles = SpecHelpers.collectRelativeFileNames(basicOutput);
     actualOutputFiles.sort();
+    expectedOutputFiles.sort();
     expect(actualOutputFiles).toEqual(expectedOutputFiles);
   });
 

--- a/src/tilesetProcessing/BasicTilesetProcessor.ts
+++ b/src/tilesetProcessing/BasicTilesetProcessor.ts
@@ -356,7 +356,7 @@ export class BasicTilesetProcessor extends TilesetProcessor {
    * @param tile - The tile
    * @param contentUris - The content URIs
    */
-  private static updateTileContent(tile: Tile, contentUris: string[]) {
+  static updateTileContent(tile: Tile, contentUris: string[]) {
     if (contentUris.length === 0) {
       delete tile.content;
       delete tile.contents;

--- a/src/tilesetProcessing/BasicTilesetProcessor.ts
+++ b/src/tilesetProcessing/BasicTilesetProcessor.ts
@@ -373,6 +373,7 @@ export class BasicTilesetProcessor extends TilesetProcessor {
         tile.content = content;
         delete tile.contents;
       }
+      return;
     }
 
     const newContents: Content[] = [];


### PR DESCRIPTION
When applying things like `b3dmToGlb` as part of a content stage within a pipeline, the output used `"contents"` even when there only was a single content, and a `"content"` would have been sufficient. While this is "valid", it's certainly unexpected and was not intentional - it happened due to a missing `return`... 

I'm still thinking about how to cover this with a spec...