### PR TITLE
Use auto-generated structure classes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "plugins": ["@typescript-eslint"],
   "root": true,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-empty-interface": "off"
   }
 }

--- a/src/structure/Asset.ts
+++ b/src/structure/Asset.ts
@@ -1,7 +1,19 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * Metadata about the entire tileset.
+ * @internal
+ */
 export interface Asset extends RootProperty {
+  /**
+   * The 3D Tiles version. The version defines the JSON schema for the
+   * tileset JSON and the base set of tile formats.
+   */
   version: string;
+
+  /**
+   * Application-specific version of this tileset e.g. for when an existing
+   * tileset is updated.
+   */
   tilesetVersion?: string;
 }

--- a/src/structure/Availability.ts
+++ b/src/structure/Availability.ts
@@ -1,8 +1,27 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * An object describing the availability of a set of elements.
+ * @internal
+ */
 export interface Availability extends RootProperty {
+  /**
+   * Index of a buffer view that indicates whether each element is
+   * available. The bitstream conforms to the boolean array encoding
+   * described in the 3D Metadata specification. If an element is available
+   * its bit is 1 and if it is unavailable its bit is 0.
+   */
   bitstream?: number;
+
+  /**
+   * A number indicating how many 1 bits exist in the availability
+   * bitstream.
+   */
   availableCount?: number;
+
+  /**
+   * Integer indicating whether all of the elements are available (1) or
+   * all are unavailable (0).
+   */
   constant?: number;
 }

--- a/src/structure/BoundingVolume.ts
+++ b/src/structure/BoundingVolume.ts
@@ -1,8 +1,39 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * A bounding volume that encloses a tile or its content. At least one
+ * bounding volume property is required. Bounding volumes include `box`
+ * `region` or `sphere`.
+ * @internal
+ */
 export interface BoundingVolume extends RootProperty {
-  region?: number[];
+  /**
+   * An array of 12 numbers that define an oriented bounding box. The first
+   * three elements define the x y and z values for the center of the box.
+   * The next three elements (with indices 3 4 and 5) define the x axis
+   * direction and half-length. The next three elements (indices 6 7 and 8)
+   * define the y axis direction and half-length. The last three elements
+   * (indices 9 10 and 11) define the z axis direction and half-length.
+   */
   box?: number[];
+
+  /**
+   * An array of six numbers that define a bounding geographic region in
+   * EPSG:4979 coordinates with the order [west south east north minimum
+   * height maximum height]. Longitudes and latitudes are in radians. The
+   * range for latitudes is [-PI/2 PI/2]. The range for longitudes is [-PI
+   * PI]. The value that is given as the 'south' of the region shall not be
+   * larger than the value for the 'north' of the region. The heights are
+   * in meters above (or below) the WGS84 ellipsoid. The 'minimum height'
+   * shall not be larger than the 'maximum height'.
+   */
+  region?: number[];
+
+  /**
+   * An array of four numbers that define a bounding sphere. The first
+   * three elements define the x y and z values for the center of the
+   * sphere. The last element (with index 3) defines the radius in meters.
+   * The radius shall not be negative.
+   */
   sphere?: number[];
 }

--- a/src/structure/BufferObject.ts
+++ b/src/structure/BufferObject.ts
@@ -1,8 +1,27 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * A buffer is a binary blob. It is either the binary chunk of the
+ * subtree file or an external buffer referenced by a URI.
+ * @internal
+ */
 export interface BufferObject extends RootProperty {
+  /**
+   * The URI (or IRI) of the file that contains the binary buffer data.
+   * Relative paths are relative to the file containing the buffer JSON.
+   * `uri` is required when using the JSON subtree format and not required
+   * when using the binary subtree format - when omitted the buffer refers
+   * to the binary chunk of the subtree file. Data URIs are not allowed.
+   */
   uri?: string;
+
+  /**
+   * The length of the buffer in bytes.
+   */
   byteLength: number;
+
+  /**
+   * The name of the buffer.
+   */
   name?: string;
 }

--- a/src/structure/BufferView.ts
+++ b/src/structure/BufferView.ts
@@ -1,9 +1,27 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * A contiguous subset of a buffer
+ * @internal
+ */
 export interface BufferView extends RootProperty {
+  /**
+   * The index of the buffer.
+   */
   buffer: number;
+
+  /**
+   * The offset into the buffer in bytes.
+   */
   byteOffset: number;
+
+  /**
+   * The total byte length of the buffer view.
+   */
   byteLength: number;
+
+  /**
+   * The name of the `bufferView`.
+   */
   name?: string;
 }

--- a/src/structure/Content.ts
+++ b/src/structure/Content.ts
@@ -1,11 +1,34 @@
+import { RootProperty } from "./RootProperty";
 import { BoundingVolume } from "./BoundingVolume";
 import { MetadataEntity } from "./MetadataEntity";
-import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * Metadata about the tile's content and a link to the content.
+ * @internal
+ */
 export interface Content extends RootProperty {
+  /**
+   * An optional bounding volume that tightly encloses tile content.
+   * tile.boundingVolume provides spatial coherence and
+   * tile.content.boundingVolume enables tight view frustum culling. When
+   * this is omitted tile.boundingVolume is used.
+   */
   boundingVolume?: BoundingVolume;
+
+  /**
+   * A uri that points to tile content. When the uri is relative it is
+   * relative to the referring tileset JSON file.
+   */
   uri: string;
+
+  /**
+   * Metadata that is associated with this content.
+   */
   metadata?: MetadataEntity;
+
+  /**
+   * The group this content belongs to. The value is an index into the
+   * array of `groups` that is defined for the containing tileset.
+   */
   group?: number;
 }

--- a/src/structure/Group.ts
+++ b/src/structure/Group.ts
@@ -1,5 +1,7 @@
 import { MetadataEntity } from "./MetadataEntity";
 
-/** @internal */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+/**
+ * An object containing metadata about a group.
+ * @internal
+ */
 export interface Group extends MetadataEntity {}

--- a/src/structure/Metadata/ClassProperty.ts
+++ b/src/structure/Metadata/ClassProperty.ts
@@ -1,21 +1,123 @@
 import { RootProperty } from "../RootProperty";
 
-/** @internal */
+/**
+ * A single property of a metadata class.
+ * @internal
+ */
 export interface ClassProperty extends RootProperty {
+  /**
+   * The name of the property e.g. for display purposes.
+   */
   name?: string;
+
+  /**
+   * The description of the property.
+   */
   description?: string;
+
+  /**
+   * The element type.
+   */
   type: string;
+
+  /**
+   * The datatype of the element's components. Required for `SCALAR` `VECN`
+   * and `MATN` types and disallowed for other types.
+   */
   componentType?: string;
+
+  /**
+   * Enum ID as declared in the `enums` dictionary. Required when `type` is
+   * `ENUM`. Disallowed when `type` is not `ENUM`
+   */
   enumType?: string;
+
+  /**
+   * Whether the property is an array. When `count` is defined the property
+   * is a fixed-length array. Otherwise the property is a variable-length
+   * array.
+   */
   array?: boolean;
+
+  /**
+   * The number of array elements. May only be defined when `array` is
+   * `true`.
+   */
   count?: number;
+
+  /**
+   * Specifies whether integer values are normalized. Only applicable to
+   * `SCALAR` `VECN` and `MATN` types with integer component types. For
+   * unsigned integer component types values are normalized between `[0.0
+   * 1.0]`. For signed integer component types values are normalized
+   * between `[-1.0 1.0]`. For all other component types this property
+   * shall be false.
+   */
   normalized?: boolean;
+
+  /**
+   * An offset to apply to property values. Only applicable to `SCALAR`
+   * `VECN` and `MATN` types when the component type is `FLOAT32` or
+   * `FLOAT64` or when the property is `normalized`. Not applicable to
+   * variable-length arrays.
+   */
   offset?: any;
+
+  /**
+   * A scale to apply to property values. Only applicable to `SCALAR`
+   * `VECN` and `MATN` types when the component type is `FLOAT32` or
+   * `FLOAT64` or when the property is `normalized`. Not applicable to
+   * variable-length arrays.
+   */
   scale?: any;
+
+  /**
+   * Maximum allowed value for the property. Only applicable to `SCALAR`
+   * `VECN` and `MATN` types. This is the maximum of all property values
+   * after the transforms based on the `normalized` `offset` and `scale`
+   * properties have been applied. Not applicable to variable-length
+   * arrays.
+   */
   max?: any;
+
+  /**
+   * Minimum allowed value for the property. Only applicable to `SCALAR`
+   * `VECN` and `MATN` types. This is the minimum of all property values
+   * after the transforms based on the `normalized` `offset` and `scale`
+   * properties have been applied. Not applicable to variable-length
+   * arrays.
+   */
   min?: any;
+
+  /**
+   * If required the property shall be present in every entity conforming
+   * to the class. If not required individual entities may include `noData`
+   * values or the entire property may be omitted. As a result `noData` has
+   * no effect on a required property. Client implementations may use
+   * required properties to make performance optimizations.
+   */
   required?: boolean;
+
+  /**
+   * A `noData` value represents missing data — also known as a sentinel
+   * value — wherever it appears. `BOOLEAN` properties may not specify
+   * `noData` values. This is given as the plain property value without the
+   * transforms from the `normalized` `offset` and `scale` properties.
+   * Shall not be defined if `required` is true.
+   */
   noData?: any;
+
+  /**
+   * A default value to use when encountering a `noData` value or an
+   * omitted property. The value is given in its final form taking the
+   * effect of `normalized` `offset` and `scale` properties into account.
+   * Shall not be defined if `required` is true.
+   */
   default?: any;
+
+  /**
+   * An identifier that describes how this property should be interpreted.
+   * The semantic cannot be used by other properties in the class.
+   */
   semantic?: string;
 }

--- a/src/structure/Metadata/EnumValue.ts
+++ b/src/structure/Metadata/EnumValue.ts
@@ -1,8 +1,22 @@
 import { RootProperty } from "../RootProperty";
 
-/** @internal */
+/**
+ * An enum value.
+ * @internal
+ */
 export interface EnumValue extends RootProperty {
+  /**
+   * The name of the enum value.
+   */
   name: string;
+
+  /**
+   * The description of the enum value.
+   */
   description?: string;
+
+  /**
+   * The integer enum value.
+   */
   value: number;
 }

--- a/src/structure/Metadata/MetadataClass.ts
+++ b/src/structure/Metadata/MetadataClass.ts
@@ -1,9 +1,26 @@
 import { RootProperty } from "../RootProperty";
 import { ClassProperty } from "./ClassProperty";
 
-/** @internal */
+/**
+ * A class containing a set of properties.
+ * @internal
+ */
 export interface MetadataClass extends RootProperty {
+  /**
+   * The name of the class e.g. for display purposes.
+   */
   name?: string;
+
+  /**
+   * The description of the class.
+   */
   description?: string;
+
+  /**
+   * A dictionary where each key is a property ID and each value is an
+   * object defining the property. Property IDs shall be alphanumeric
+   * identifiers matching the regular expression
+   * `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+   */
   properties?: { [key: string]: ClassProperty };
 }

--- a/src/structure/Metadata/MetadataEnum.ts
+++ b/src/structure/Metadata/MetadataEnum.ts
@@ -1,10 +1,29 @@
 import { RootProperty } from "../RootProperty";
 import { EnumValue } from "./EnumValue";
 
-/** @internal */
+/**
+ * An object defining the values of an enum.
+ * @internal
+ */
 export interface MetadataEnum extends RootProperty {
+  /**
+   * The name of the enum e.g. for display purposes.
+   */
   name?: string;
+
+  /**
+   * The description of the enum.
+   */
   description?: string;
+
+  /**
+   * The type of the integer enum value.
+   */
   valueType?: string;
+
+  /**
+   * An array of enum values. Duplicate names or duplicate integer values
+   * are not allowed.
+   */
   values: EnumValue[];
 }

--- a/src/structure/Metadata/Schema.ts
+++ b/src/structure/Metadata/Schema.ts
@@ -2,12 +2,45 @@ import { RootProperty } from "../RootProperty";
 import { MetadataClass } from "./MetadataClass";
 import { MetadataEnum } from "./MetadataEnum";
 
-/** @internal */
+/**
+ * An object defining classes and enums.
+ * @internal
+ */
 export interface Schema extends RootProperty {
+  /**
+   * Unique identifier for the schema. Schema IDs shall be alphanumeric
+   * identifiers matching the regular expression
+   * `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+   */
   id: string;
+
+  /**
+   * The name of the schema e.g. for display purposes.
+   */
   name?: string;
+
+  /**
+   * The description of the schema.
+   */
   description?: string;
+
+  /**
+   * Application-specific version of the schema.
+   */
   version?: string;
+
+  /**
+   * A dictionary where each key is a class ID and each value is an object
+   * defining the class. Class IDs shall be alphanumeric identifiers
+   * matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+   */
   classes?: { [key: string]: MetadataClass };
+
+  /**
+   * A dictionary where each key is an enum ID and each value is an object
+   * defining the values for the enum. Enum IDs shall be alphanumeric
+   * identifiers matching the regular expression
+   * `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+   */
   enums?: { [key: string]: MetadataEnum };
 }

--- a/src/structure/MetadataEntity.ts
+++ b/src/structure/MetadataEntity.ts
@@ -1,7 +1,26 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * An object containing a reference to a class from a metadata schema and
+ * property values that conform to the properties of that class.
+ * @internal
+ */
 export interface MetadataEntity extends RootProperty {
+  /**
+   * The class that property values conform to. The value shall be a class
+   * ID declared in the `classes` dictionary of the metadata schema.
+   */
   class: string;
+
+  /**
+   * A dictionary where each key corresponds to a property ID in the class'
+   * `properties` dictionary and each value contains the property values.
+   * The type of the value shall match the property definition: For
+   * `BOOLEAN` use `true` or `false`. For `STRING` use a JSON string. For
+   * numeric types use a JSON number. For `ENUM` use a valid enum `name`
+   * not an integer value. For `ARRAY` `VECN` and `MATN` types use a JSON
+   * array containing values matching the `componentType`. Required
+   * properties shall be included in this dictionary.
+   */
   properties?: { [key: string]: any };
 }

--- a/src/structure/Properties.ts
+++ b/src/structure/Properties.ts
@@ -1,7 +1,19 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * A dictionary object of metadata about per-feature properties.
+ * @internal
+ */
 export interface Properties extends RootProperty {
-  minimum: number;
+  /**
+   * The maximum value of this property of all the features in the tileset.
+   * The maximum value shall not be larger than the minimum value.
+   */
   maximum: number;
+
+  /**
+   * The minimum value of this property of all the features in the tileset.
+   * The maximum value shall not be larger than the minimum value.
+   */
+  minimum: number;
 }

--- a/src/structure/PropertyTable.ts
+++ b/src/structure/PropertyTable.ts
@@ -1,10 +1,33 @@
-import { PropertyTableProperty } from "./PropertyTableProperty";
 import { RootProperty } from "./RootProperty";
+import { PropertyTableProperty } from "./PropertyTableProperty";
 
-/** @internal */
+/**
+ * Properties conforming to a class organized as property values stored
+ * in binary columnar arrays.
+ * @internal
+ */
 export interface PropertyTable extends RootProperty {
+  /**
+   * The name of the property table e.g. for display purposes.
+   */
   name?: string;
+
+  /**
+   * The class that property values conform to. The value shall be a class
+   * ID declared in the `classes` dictionary.
+   */
   class: string;
+
+  /**
+   * The number of elements in each property array.
+   */
   count: number;
+
+  /**
+   * A dictionary where each key corresponds to a property ID in the class'
+   * `properties` dictionary and each value is an object describing where
+   * property values are stored. Required properties shall be included in
+   * this dictionary.
+   */
   properties?: { [key: string]: PropertyTableProperty };
 }

--- a/src/structure/PropertyTableProperty.ts
+++ b/src/structure/PropertyTableProperty.ts
@@ -1,14 +1,96 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * An array of binary property values. This represents one column of a
+ * property table and contains one value of a certain property for each
+ * metadata entity.
+ * @internal
+ */
 export interface PropertyTableProperty extends RootProperty {
+  /**
+   * The index of the buffer view containing property values. The data type
+   * of property values is determined by the property definition: When
+   * `type` is `BOOLEAN` values are packed into a bitstream. When `type` is
+   * `STRING` values are stored as byte sequences and decoded as UTF-8
+   * strings. When `type` is `SCALAR` `VECN` or `MATN` the values are
+   * stored as the provided `componentType` and the buffer view
+   * `byteOffset` shall be aligned to a multiple of the `componentType`
+   * size. When `type` is `ENUM` values are stored as the enum's
+   * `valueType` and the buffer view `byteOffset` shall be aligned to a
+   * multiple of the `valueType` size. Each enum value in the array shall
+   * match one of the allowed values in the enum definition. `arrayOffsets`
+   * is required for variable-length arrays and `stringOffsets` is required
+   * for strings (for variable-length arrays of strings both are required).
+   */
   values: number;
+
+  /**
+   * The index of the buffer view containing offsets for variable-length
+   * arrays. The number of offsets is equal to the property table `count`
+   * plus one. The offsets represent the start positions of each array with
+   * the last offset representing the position after the last array. The
+   * array length is computed using the difference between the subsequent
+   * offset and the current offset. If `type` is `STRING` the offsets index
+   * into the string offsets array (stored in `stringOffsets`) otherwise
+   * they index into the property array (stored in `values`). The data type
+   * of these offsets is determined by `arrayOffsetType`. The buffer view
+   * `byteOffset` shall be aligned to a multiple of the `arrayOffsetType`
+   * size.
+   */
   arrayOffsets?: number;
+
+  /**
+   * The index of the buffer view containing offsets for strings. The
+   * number of offsets is equal to the number of string elements plus one.
+   * The offsets represent the byte offsets of each string in the property
+   * array (stored in `values`) with the last offset representing the byte
+   * offset after the last string. The string byte length is computed using
+   * the difference between the subsequent offset and the current offset.
+   * The data type of these offsets is determined by `stringOffsetType`.
+   * The buffer view `byteOffset` shall be aligned to a multiple of the
+   * `stringOffsetType` size.
+   */
   stringOffsets?: number;
+
+  /**
+   * The type of values in `arrayOffsets`.
+   */
   arrayOffsetType?: string;
+
+  /**
+   * The type of values in `stringOffsets`.
+   */
   stringOffsetType?: string;
-  offset: any;
-  scale: any;
-  max: any;
-  min: any;
+
+  /**
+   * An offset to apply to property values. Only applicable when the
+   * component type is `FLOAT32` or `FLOAT64` or when the property is
+   * `normalized`. Overrides the class property's `offset` if both are
+   * defined.
+   */
+  offset?: any;
+
+  /**
+   * A scale to apply to property values. Only applicable when the
+   * component type is `FLOAT32` or `FLOAT64` or when the property is
+   * `normalized`. Overrides the class property's `scale` if both are
+   * defined.
+   */
+  scale?: any;
+
+  /**
+   * Maximum value present in the property values. Only applicable to
+   * `SCALAR` `VECN` and `MATN` types. This is the maximum of all property
+   * values after the transforms based on the `normalized` `offset` and
+   * `scale` properties have been applied.
+   */
+  max?: any;
+
+  /**
+   * Minimum value present in the property values. Only applicable to
+   * `SCALAR` `VECN` and `MATN` types. This is the minimum of all property
+   * values after the transforms based on the `normalized` `offset` and
+   * `scale` properties have been applied.
+   */
+  min?: any;
 }

--- a/src/structure/RootProperty.ts
+++ b/src/structure/RootProperty.ts
@@ -1,5 +1,13 @@
-/** @internal */
+/**
+ * A basis for storing extensions and extras.
+ * @internal
+ */
 export interface RootProperty {
+  /**
+   */
   extensions?: { [key: string]: { [key: string]: any } };
+
+  /**
+   */
   extras?: { [key: string]: any };
 }

--- a/src/structure/Statistics.ts
+++ b/src/structure/Statistics.ts
@@ -1,7 +1,16 @@
 import { RootProperty } from "./RootProperty";
 import { StatisticsClass } from "./StatisticsClass";
 
-/** @internal */
+/**
+ * Statistics about entities.
+ * @internal
+ */
 export interface Statistics extends RootProperty {
-  classes: { [key: string]: StatisticsClass };
+  /**
+   * A dictionary where each key corresponds to a class ID in the `classes`
+   * dictionary of the metatata schema that was defined for the tileset
+   * that contains these statistics. Each value is an object containing
+   * statistics about entities that conform to the class.
+   */
+  classes?: { [key: string]: StatisticsClass };
 }

--- a/src/structure/StatisticsClass.ts
+++ b/src/structure/StatisticsClass.ts
@@ -1,8 +1,21 @@
 import { RootProperty } from "./RootProperty";
 import { StatisticsClassProperty } from "./StatisticsClassProperty";
 
-/** @internal */
+/**
+ * Statistics about entities that conform to a class that was defined in
+ * a metadata schema.
+ * @internal
+ */
 export interface StatisticsClass extends RootProperty {
+  /**
+   * The number of entities that conform to the class.
+   */
   count?: number;
-  properties: { [key: string]: StatisticsClassProperty };
+
+  /**
+   * A dictionary where each key corresponds to a property ID in the class'
+   * `properties` dictionary and each value is an object containing
+   * statistics about property values.
+   */
+  properties?: { [key: string]: StatisticsClassProperty };
 }

--- a/src/structure/StatisticsClassProperty.ts
+++ b/src/structure/StatisticsClassProperty.ts
@@ -1,13 +1,71 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * Statistics about property values.
+ * @internal
+ */
 export interface StatisticsClassProperty extends RootProperty {
-  min: any;
-  max: any;
-  mean: any;
-  median: any;
-  standardDeviation: any;
-  variance: any;
-  sum: any;
+  /**
+   * The minimum property value occurring in the tileset. Only applicable
+   * to `SCALAR` `VECN` and `MATN` types. This is the minimum of all
+   * property values after the transforms based on the `normalized`
+   * `offset` and `scale` properties have been applied.
+   */
+  min?: any;
+
+  /**
+   * The maximum property value occurring in the tileset. Only applicable
+   * to `SCALAR` `VECN` and `MATN` types. This is the maximum of all
+   * property values after the transforms based on the `normalized`
+   * `offset` and `scale` properties have been applied.
+   */
+  max?: any;
+
+  /**
+   * The arithmetic mean of property values occurring in the tileset. Only
+   * applicable to `SCALAR` `VECN` and `MATN` types. This is the mean of
+   * all property values after the transforms based on the `normalized`
+   * `offset` and `scale` properties have been applied.
+   */
+  mean?: any;
+
+  /**
+   * The median of property values occurring in the tileset. Only
+   * applicable to `SCALAR` `VECN` and `MATN` types. This is the median of
+   * all property values after the transforms based on the `normalized`
+   * `offset` and `scale` properties have been applied.
+   */
+  median?: any;
+
+  /**
+   * The standard deviation of property values occurring in the tileset.
+   * Only applicable to `SCALAR` `VECN` and `MATN` types. This is the
+   * standard deviation of all property values after the transforms based
+   * on the `normalized` `offset` and `scale` properties have been applied.
+   */
+  standardDeviation?: any;
+
+  /**
+   * The variance of property values occurring in the tileset. Only
+   * applicable to `SCALAR` `VECN` and `MATN` types. This is the variance
+   * of all property values after the transforms based on the `normalized`
+   * `offset` and `scale` properties have been applied.
+   */
+  variance?: any;
+
+  /**
+   * The sum of property values occurring in the tileset. Only applicable
+   * to `SCALAR` `VECN` and `MATN` types. This is the sum of all property
+   * values after the transforms based on the `normalized` `offset` and
+   * `scale` properties have been applied.
+   */
+  sum?: any;
+
+  /**
+   * A dictionary where each key corresponds to an enum `name` and each
+   * value is the number of occurrences of that enum. Only applicable when
+   * `type` is `ENUM`. For fixed-length arrays this is an array of
+   * component-wise occurrences.
+   */
   occurrences?: { [key: string]: any };
 }

--- a/src/structure/Subtree.ts
+++ b/src/structure/Subtree.ts
@@ -1,19 +1,91 @@
-import { Availability } from "./Availability";
+import { RootProperty } from "./RootProperty";
 import { BufferObject } from "./BufferObject";
 import { BufferView } from "./BufferView";
-import { MetadataEntity } from "./MetadataEntity";
 import { PropertyTable } from "./PropertyTable";
-import { RootProperty } from "./RootProperty";
+import { Availability } from "./Availability";
+import { MetadataEntity } from "./MetadataEntity";
 
-/** @internal */
+/**
+ * An object describing the availability of tiles and content in a
+ * subtree as well as availability of children subtrees. May also store
+ * metadata for available tiles and content.
+ * @internal
+ */
 export interface Subtree extends RootProperty {
+  /**
+   * An array of buffers.
+   */
   buffers?: BufferObject[];
+
+  /**
+   * An array of buffer views.
+   */
   bufferViews?: BufferView[];
+
+  /**
+   * An array of property tables.
+   */
   propertyTables?: PropertyTable[];
+
+  /**
+   * The availability of tiles in the subtree. The availability bitstream
+   * is a 1D boolean array where tiles are ordered by their level in the
+   * subtree and Morton index within that level. A tile's availability is
+   * determined by a single bit 1 meaning a tile exists at that spatial
+   * index and 0 meaning it does not. The number of elements in the array
+   * is `(N^subtreeLevels - 1)/(N - 1)` where N is 4 for subdivision scheme
+   * `QUADTREE` and 8 for `OCTREE`. Availability may be stored in a buffer
+   * view or as a constant value that applies to all tiles. If a non-root
+   * tile's availability is 1 its parent tile's availability shall also be
+   * 1. `tileAvailability.constant: 0` is disallowed as subtrees shall have
+   * at least one tile.
+   */
   tileAvailability: Availability;
+
+  /**
+   * An array of content availability objects. If the tile has a single
+   * content this array will have one element; if the tile has multiple
+   * contents - as supported by 3DTILES_multiple_contents and 3D Tiles 1.1
+   * - this array will have multiple elements.
+   */
   contentAvailability?: Availability[];
+
+  /**
+   * The availability of children subtrees. The availability bitstream is a
+   * 1D boolean array where subtrees are ordered by their Morton index in
+   * the level of the tree immediately below the bottom row of the subtree.
+   * A child subtree's availability is determined by a single bit 1 meaning
+   * a subtree exists at that spatial index and 0 meaning it does not. The
+   * number of elements in the array is `N^subtreeLevels` where N is 4 for
+   * subdivision scheme `QUADTREE` and 8 for `OCTREE`. Availability may be
+   * stored in a buffer view or as a constant value that applies to all
+   * child subtrees. If availability is 0 for all child subtrees then the
+   * tileset does not subdivide further.
+   */
   childSubtreeAvailability: Availability;
+
+  /**
+   * Index of the property table containing tile metadata. Tile metadata
+   * only exists for available tiles and is tightly packed by increasing
+   * tile index. To access individual tile metadata implementations may
+   * create a mapping from tile indices to tile metadata indices.
+   */
   tileMetadata?: number;
+
+  /**
+   * An array of indexes to property tables containing content metadata. If
+   * the tile has a single content this array will have one element; if the
+   * tile has multiple contents - as supported by 3DTILES_multiple_contents
+   * and 3D Tiles 1.1 - this array will have multiple elements. Content
+   * metadata only exists for available contents and is tightly packed by
+   * increasing tile index. To access individual content metadata
+   * implementations may create a mapping from tile indices to content
+   * metadata indices.
+   */
   contentMetadata?: number[];
+
+  /**
+   * Subtree metadata encoded in JSON.
+   */
   subtreeMetadata?: MetadataEntity;
 }

--- a/src/structure/Subtrees.ts
+++ b/src/structure/Subtrees.ts
@@ -1,6 +1,16 @@
 import { RootProperty } from "./RootProperty";
 
-/** @internal */
+/**
+ * An object describing the location of subtree files.
+ * @internal
+ */
 export interface Subtrees extends RootProperty {
+  /**
+   * A template URI pointing to subtree files. A subtree is a fixed-depth
+   * (defined by `subtreeLevels`) portion of the tree to keep memory use
+   * bounded. The URI of each file is substituted with the subtree root's
+   * global level x and y. For subdivision scheme `OCTREE` z shall also be
+   * given. Relative paths are relative to the tileset JSON.
+   */
   uri: string;
 }

--- a/src/structure/Tile.ts
+++ b/src/structure/Tile.ts
@@ -12,21 +12,21 @@ export interface Tile extends RootProperty {
   /**
    * The bounding volume that encloses the tile.
    */
-  boundingVolume:BoundingVolume;
+  boundingVolume: BoundingVolume;
 
   /**
    * Optional bounding volume that defines the volume the viewer shall be
    * inside of before the tile's content will be requested and before the
    * tile will be refined based on geometricError.
    */
-  viewerRequestVolume?:BoundingVolume;
+  viewerRequestVolume?: BoundingVolume;
 
   /**
    * The error in meters introduced if this tile is rendered and its
    * children are not. At runtime the geometric error is used to compute
    * screen space error (SSE) i.e. the error measured in pixels.
    */
-  geometricError:number;
+  geometricError: number;
 
   /**
    * Specifies if additive or replacement refinement is used when
@@ -34,7 +34,7 @@ export interface Tile extends RootProperty {
    * the root tile of a tileset; it is optional for all other tiles. The
    * default is to inherit from the parent tile.
    */
-  refine?:string;
+  refine?: string;
 
   /**
    * A floating-point 4x4 affine transformation matrix stored in
@@ -47,30 +47,30 @@ export interface Tile extends RootProperty {
    * region defined in EPSG:4979 coordinates. `transform` scales the
    * `geometricError` by the maximum scaling factor from the matrix.
    */
-  transform?:number[];
+  transform?: number[];
 
   /**
    * Metadata about the tile's content and a link to the content. When this
    * is omitted the tile is just used for culling. When this is defined
    * then `contents` shall be undefined.
    */
-  content?:Content;
+  content?: Content;
 
   /**
    * An array of contents. When this is defined then `content` shall be
    * undefined.
    */
-  contents?:Content[];
+  contents?: Content[];
 
   /**
    * A metadata entity that is associated with this tile.
    */
-  metadata?:MetadataEntity;
+  metadata?: MetadataEntity;
 
   /**
    * An object that describes the implicit subdivision of this tile.
    */
-  implicitTiling?:TileImplicitTiling;
+  implicitTiling?: TileImplicitTiling;
 
   /**
    * An array of objects that define child tiles. Each child tile content
@@ -79,9 +79,5 @@ export interface Tile extends RootProperty {
    * leaf tiles the length of this array is zero and children may not be
    * defined.
    */
-  children?:Tile[];
-
+  children?: Tile[];
 }
-
-
-

--- a/src/structure/Tile.ts
+++ b/src/structure/Tile.ts
@@ -1,19 +1,87 @@
+import { RootProperty } from "./RootProperty";
 import { BoundingVolume } from "./BoundingVolume";
 import { Content } from "./Content";
 import { MetadataEntity } from "./MetadataEntity";
-import { RootProperty } from "./RootProperty";
 import { TileImplicitTiling } from "./TileImplicitTiling";
 
-/** @internal */
+/**
+ * A tile in a 3D Tiles tileset.
+ * @internal
+ */
 export interface Tile extends RootProperty {
-  boundingVolume: BoundingVolume;
-  viewerRequestVolume?: BoundingVolume;
-  geometricError: number;
-  refine?: string;
-  transform?: number[];
-  content?: Content;
-  contents?: Content[];
-  metadata?: MetadataEntity;
-  implicitTiling?: TileImplicitTiling;
-  children?: Tile[];
+  /**
+   * The bounding volume that encloses the tile.
+   */
+  boundingVolume:BoundingVolume;
+
+  /**
+   * Optional bounding volume that defines the volume the viewer shall be
+   * inside of before the tile's content will be requested and before the
+   * tile will be refined based on geometricError.
+   */
+  viewerRequestVolume?:BoundingVolume;
+
+  /**
+   * The error in meters introduced if this tile is rendered and its
+   * children are not. At runtime the geometric error is used to compute
+   * screen space error (SSE) i.e. the error measured in pixels.
+   */
+  geometricError:number;
+
+  /**
+   * Specifies if additive or replacement refinement is used when
+   * traversing the tileset for rendering. This property is required for
+   * the root tile of a tileset; it is optional for all other tiles. The
+   * default is to inherit from the parent tile.
+   */
+  refine?:string;
+
+  /**
+   * A floating-point 4x4 affine transformation matrix stored in
+   * column-major order that transforms the tile's content--i.e. its
+   * features as well as content.boundingVolume boundingVolume and
+   * viewerRequestVolume--from the tile's local coordinate system to the
+   * parent tile's coordinate system or in the case of a root tile from the
+   * tile's local coordinate system to the tileset's coordinate system.
+   * `transform` does not apply to any volume property when the volume is a
+   * region defined in EPSG:4979 coordinates. `transform` scales the
+   * `geometricError` by the maximum scaling factor from the matrix.
+   */
+  transform?:number[];
+
+  /**
+   * Metadata about the tile's content and a link to the content. When this
+   * is omitted the tile is just used for culling. When this is defined
+   * then `contents` shall be undefined.
+   */
+  content?:Content;
+
+  /**
+   * An array of contents. When this is defined then `content` shall be
+   * undefined.
+   */
+  contents?:Content[];
+
+  /**
+   * A metadata entity that is associated with this tile.
+   */
+  metadata?:MetadataEntity;
+
+  /**
+   * An object that describes the implicit subdivision of this tile.
+   */
+  implicitTiling?:TileImplicitTiling;
+
+  /**
+   * An array of objects that define child tiles. Each child tile content
+   * is fully enclosed by its parent tile's bounding volume and generally
+   * has a geometricError less than its parent tile's geometricError. For
+   * leaf tiles the length of this array is zero and children may not be
+   * defined.
+   */
+  children?:Tile[];
+
 }
+
+
+

--- a/src/structure/TileImplicitTiling.ts
+++ b/src/structure/TileImplicitTiling.ts
@@ -1,10 +1,32 @@
 import { RootProperty } from "./RootProperty";
 import { Subtrees } from "./Subtrees";
 
-/** @internal */
+/**
+ * This object allows a tile to be implicitly subdivided. Tile and
+ * content availability and metadata is stored in subtrees which are
+ * referenced externally.
+ * @internal
+ */
 export interface TileImplicitTiling extends RootProperty {
+  /**
+   * A string describing the subdivision scheme used within the tileset.
+   */
   subdivisionScheme: string;
+
+  /**
+   * The number of distinct levels in each subtree. For example a quadtree
+   * with `subtreeLevels = 2` will have subtrees with 5 nodes (one root and
+   * 4 children).
+   */
   subtreeLevels: number;
+
+  /**
+   * The numbers of the levels in the tree with available tiles.
+   */
   availableLevels: number;
+
+  /**
+   * An object describing the location of subtree files.
+   */
   subtrees: Subtrees;
 }

--- a/src/structure/Tileset.ts
+++ b/src/structure/Tileset.ts
@@ -1,23 +1,77 @@
-import { Asset } from "./Asset";
-import { Group } from "./Group";
-import { Schema } from "./Metadata/Schema";
-import { MetadataEntity } from "./MetadataEntity";
-import { Properties } from "./Properties";
 import { RootProperty } from "./RootProperty";
+import { Asset } from "./Asset";
+import { Properties } from "./Properties";
+import { Schema } from "./Metadata/Schema";
 import { Statistics } from "./Statistics";
+import { Group } from "./Group";
+import { MetadataEntity } from "./MetadataEntity";
 import { Tile } from "./Tile";
 
-/** @internal */
+/**
+ * A 3D Tiles tileset.
+ * @internal
+ */
 export interface Tileset extends RootProperty {
+  /**
+   * Metadata about the entire tileset.
+   */
   asset: Asset;
-  properties?: Properties;
+
+  /**
+   * A dictionary object of metadata about per-feature properties.
+   */
+  properties?: { [key: string]: Properties };
+
+  /**
+   * An object defining the structure of metadata classes and enums. When
+   * this is defined then `schemaUri` shall be undefined.
+   */
   schema?: Schema;
+
+  /**
+   * The URI (or IRI) of the external schema file. When this is defined
+   * then `schema` shall be undefined.
+   */
   schemaUri?: string;
+
+  /**
+   * An object containing statistics about metadata entities.
+   */
   statistics?: Statistics;
+
+  /**
+   * An array of groups that tile content may belong to. Each element of
+   * this array is a metadata entity that describes the group. The tile
+   * content `group` property is an index into this array.
+   */
   groups?: Group[];
+
+  /**
+   * A metadata entity that is associated with this tileset.
+   */
   metadata?: MetadataEntity;
+
+  /**
+   * The error in meters introduced if this tileset is not rendered. At
+   * runtime the geometric error is used to compute screen space error
+   * (SSE) i.e. the error measured in pixels.
+   */
   geometricError: number;
+
+  /**
+   * The root tile.
+   */
   root: Tile;
+
+  /**
+   * Names of 3D Tiles extensions used somewhere in this tileset.
+   */
   extensionsUsed?: string[];
+
+  /**
+   * Names of 3D Tiles extensions required to properly load this tileset.
+   * Each element of this array shall also be contained in
+   * `extensionsUsed`.
+   */
   extensionsRequired?: string[];
 }


### PR DESCRIPTION
Addressing https://github.com/CesiumGS/3d-tiles-tools/issues/20

The `structure` directory contains classes for the elements that correspond to the 3D Tiles JSON schema (like `Tileset`, `BoundingVolume` and such). These are plain old structures - i.e. only properties, but no functions on them.

These classes had been created manually (originally in the validator), and did not include any documentation. 

There are some libraries for auto-generating TypeScript from JSON schema (but surprisingly few). I tried out https://github.com/bcherny/json-schema-to-typescript but ... this had some issues (largely revolving around resolving `$ref`, probably due to unclear JSON schema version support). I have **not** yet tried out https://github.com/ThomasAribart/json-schema-to-ts . 

Instead, I just created these classes with a modified version of our good old friend `wetzel`. The PR is at https://github.com/CesiumGS/wetzel/pull/87 , but mainly for tracking purposes: Preferably, it should **never** be necessary to re-generate these classes. At least, there shouldn't be changes in the schema - we could talk about the TSDoc, but having the basic `description` as TSDoc should be fine for now:

![Cesium Structure Hints](https://user-images.githubusercontent.com/5597569/234655363-6086d53b-bc1d-4d63-bd56-d6e0cd310950.png)

There are no actual functional or structural changes associated with this PR: The generated classes basically match the ones that have already been there, but ... now with TSDoc comments.



