### PR TITLE
Add generated classes for tile formats and style

### DIFF
--- a/src/structure/Style/Style.ts
+++ b/src/structure/Style/Style.ts
@@ -1,0 +1,33 @@
+import { RootProperty } from "../RootProperty";
+
+/**
+ * A 3D Tiles style.
+ * @internal
+ */
+export interface Style extends RootProperty {
+  /**
+   * A dictionary object of `expression` strings mapped to a variable name
+   * key that may be referenced throughout the style. If an expression
+   * references a defined variable it is replaced with the evaluated result
+   * of the corresponding expression.
+   */
+  defines?: { [key: string]: string };
+
+  /**
+   * A `boolean expression` or `conditions` property which determines if a
+   * feature should be shown.
+   */
+  show?: string | string[];
+
+  /**
+   * A `color expression` or `conditions` property which determines the
+   * color blended with the feature's intrinsic color.
+   */
+  color?: string | string[];
+
+  /**
+   * A `meta` object which determines the values of non-visual properties
+   * of the feature.
+   */
+  meta?: { [key: string]: string };
+}

--- a/src/structure/TileFormats/B3dmFeatureTable.ts
+++ b/src/structure/TileFormats/B3dmFeatureTable.ts
@@ -1,0 +1,22 @@
+import { FeatureTable } from "./FeatureTable";
+
+/**
+ * A set of Batched 3D Model semantics that contain additional
+ * information about features in a tile.
+ * @internal
+ */
+export interface B3dmFeatureTable extends FeatureTable {
+  /**
+   * A `GlobalPropertyInteger` object defining an integer property for all
+   * features. Details about this property are described in the 3D Tiles
+   * specification.
+   */
+  BATCH_LENGTH: number;
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all features. Details about this property are described
+   * in the 3D Tiles specification.
+   */
+  RTC_CENTER?: BinaryBodyOffset | number[];
+}

--- a/src/structure/TileFormats/B3dmFeatureTable.ts
+++ b/src/structure/TileFormats/B3dmFeatureTable.ts
@@ -1,4 +1,5 @@
 import { FeatureTable } from "./FeatureTable";
+import { BinaryBodyOffset } from "./BinaryBodyOffset";
 
 /**
  * A set of Batched 3D Model semantics that contain additional

--- a/src/structure/TileFormats/BatchTable.ts
+++ b/src/structure/TileFormats/BatchTable.ts
@@ -1,0 +1,8 @@
+import { RootProperty } from "../RootProperty";
+
+/**
+ * A set of properties defining application-specific metadata for
+ * features in a tile.
+ * @internal
+ */
+export interface BatchTable extends RootProperty {}

--- a/src/structure/TileFormats/BinaryBodyOffset.ts
+++ b/src/structure/TileFormats/BinaryBodyOffset.ts
@@ -1,0 +1,14 @@
+import { RootProperty } from "../RootProperty";
+
+/**
+ * An object defining the offset into a section of the binary body of the
+ * features table where the property values are stored if not defined
+ * directly in the JSON.
+ * @internal
+ */
+export interface BinaryBodyOffset extends RootProperty {
+  /**
+   * The offset into the buffer in bytes.
+   */
+  byteOffset: number;
+}

--- a/src/structure/TileFormats/BinaryBodyReference.ts
+++ b/src/structure/TileFormats/BinaryBodyReference.ts
@@ -1,0 +1,24 @@
+import { RootProperty } from "../RootProperty";
+
+/**
+ * An object defining the reference to a section of the binary body of
+ * the batch table where the property values are stored if not defined
+ * directly in the JSON.
+ * @internal
+ */
+export interface BinaryBodyReference extends RootProperty {
+  /**
+   * The offset into the buffer in bytes.
+   */
+  byteOffset: number;
+
+  /**
+   * The datatype of components in the property.
+   */
+  componentType: string;
+
+  /**
+   * Specifies if the property is a scalar or vector.
+   */
+  type: string;
+}

--- a/src/structure/TileFormats/FeatureTable.ts
+++ b/src/structure/TileFormats/FeatureTable.ts
@@ -1,0 +1,8 @@
+import { RootProperty } from "../RootProperty";
+
+/**
+ * A set of semantics containing per-tile and per-feature values defining
+ * the position and appearance properties for features in a tile.
+ * @internal
+ */
+export interface FeatureTable extends RootProperty {}

--- a/src/structure/TileFormats/I3dmFeatureTable.ts
+++ b/src/structure/TileFormats/I3dmFeatureTable.ts
@@ -1,0 +1,107 @@
+import { FeatureTable } from "./FeatureTable";
+import { BinaryBodyReference } from "./BinaryBodyReference";
+
+/**
+ * A set of Instanced 3D Model semantics that contains values defining
+ * the position and appearance properties for instanced models in a tile.
+ * @internal
+ */
+export interface I3dmFeatureTable extends FeatureTable {
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  POSITION?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  POSITION_QUANTIZED?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  NORMAL_UP?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  NORMAL_RIGHT?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  NORMAL_UP_OCT32P?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  NORMAL_RIGHT_OCT32P?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  SCALE?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  SCALE_NON_UNIFORM?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  BATCH_ID?: BinaryBodyReference;
+
+  /**
+   * A `GlobalPropertyInteger` object defining an integer property for all
+   * features. Details about this property are described in the 3D Tiles
+   * specification.
+   */
+  INSTANCES_LENGTH: number;
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all features. Details about this property are described
+   * in the 3D Tiles specification.
+   */
+  RTC_CENTER?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all features. Details about this property are described
+   * in the 3D Tiles specification.
+   */
+  QUANTIZED_VOLUME_OFFSET?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all features. Details about this property are described
+   * in the 3D Tiles specification.
+   */
+  QUANTIZED_VOLUME_SCALE?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyBoolean` object defining a boolean property for all
+   * features. Details about this property are described in the 3D Tiles
+   * specification.
+   */
+  EAST_NORTH_UP?: boolean;
+}

--- a/src/structure/TileFormats/I3dmFeatureTable.ts
+++ b/src/structure/TileFormats/I3dmFeatureTable.ts
@@ -1,5 +1,6 @@
 import { FeatureTable } from "./FeatureTable";
 import { BinaryBodyReference } from "./BinaryBodyReference";
+import { BinaryBodyOffset } from "./BinaryBodyOffset";
 
 /**
  * A set of Instanced 3D Model semantics that contains values defining

--- a/src/structure/TileFormats/PntsFeatureTable.ts
+++ b/src/structure/TileFormats/PntsFeatureTable.ts
@@ -1,5 +1,6 @@
 import { FeatureTable } from "./FeatureTable";
 import { BinaryBodyReference } from "./BinaryBodyReference";
+import { BinaryBodyOffset } from "./BinaryBodyOffset";
 
 /**
  * A set of Point Cloud semantics that contains values defining the

--- a/src/structure/TileFormats/PntsFeatureTable.ts
+++ b/src/structure/TileFormats/PntsFeatureTable.ts
@@ -1,0 +1,107 @@
+import { FeatureTable } from "./FeatureTable";
+import { BinaryBodyReference } from "./BinaryBodyReference";
+
+/**
+ * A set of Point Cloud semantics that contains values defining the
+ * position and appearance properties for points in a tile.
+ * @internal
+ */
+export interface PntsFeatureTable extends FeatureTable {
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  POSITION?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  POSITION_QUANTIZED?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  RGBA?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  RGB?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  RGB565?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  NORMAL?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  NORMAL_OCT16P?: BinaryBodyReference;
+
+  /**
+   * A `BinaryBodyReference` object defining the reference to a section of
+   * the binary body where the property values are stored. Details about
+   * this property are described in the 3D Tiles specification.
+   */
+  BATCH_ID?: BinaryBodyReference;
+
+  /**
+   * A `GlobalPropertyInteger` object defining an integer property for all
+   * points. Details about this property are described in the 3D Tiles
+   * specification.
+   */
+  POINTS_LENGTH: number;
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all points. Details about this property are described in
+   * the 3D Tiles specification.
+   */
+  RTC_CENTER?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all points. Details about this property are described in
+   * the 3D Tiles specification.
+   */
+  QUANTIZED_VOLUME_OFFSET?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyCartesian3` object defining a 3-component numeric
+   * property for all points. Details about this property are described in
+   * the 3D Tiles specification.
+   */
+  QUANTIZED_VOLUME_SCALE?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyCartesian4` object defining a 4-component numeric
+   * property for all points. Details about this property are described in
+   * the 3D Tiles specification.
+   */
+  CONSTANT_RGBA?: BinaryBodyOffset | number[];
+
+  /**
+   * A `GlobalPropertyInteger` object defining an integer property for all
+   * points. Details about this property are described in the 3D Tiles
+   * specification.
+   */
+  BATCH_LENGTH?: number;
+}


### PR DESCRIPTION
Based on the state of `wetzel` from https://github.com/CesiumGS/wetzel/pull/87 , this contains `structure` classes for the "Style" and "Batch Table" and "Feature Table". Right now, this requires adding some imports manually - that still has to be fixed in `wetzel`.