### PR TITLE
Always use 'content' for single content

### DIFF
--- a/demos/ImplicitToExplicitDemo.ts
+++ b/demos/ImplicitToExplicitDemo.ts
@@ -26,6 +26,7 @@ async function buildExplicitHierarchy(
   // and contents (which contains the template URI)
   if (traversedTile.isImplicitTilesetRoot()) {
     delete explicitTile.implicitTiling;
+    delete explicitTile.content;
     delete explicitTile.contents;
   }
 

--- a/src/tilesets/Tiles.ts
+++ b/src/tilesets/Tiles.ts
@@ -15,8 +15,8 @@ export class Tiles {
    * defined `tile.contents`, or an empty array, when the tile does
    * not have contents.
    *
-   * @param tile The `Tile`
-   * @returns The content URIs
+   * @param tile - The `Tile`
+   * @returns The contents
    */
   static getContents(tile: Tile): Content[] {
     if (tile.content) {
@@ -29,6 +29,30 @@ export class Tiles {
   }
 
   /**
+   * Set the contents of the given tile.
+   *
+   * If the given array is empty, then the `content` and `contents`
+   * of the tile will be deleted. If it has length 1, then this
+   * content will become the `content` of the tile. Otherwise,
+   * the given array is set as the `contents` of the tile.
+   *
+   * @param tile - The `Tile`
+   * @param contents - The tile contents
+   */
+  static setContents(tile: Tile, contents: Content[]) {
+    if (contents.length === 0) {
+      delete tile.content;
+      delete tile.contents;
+    } else if (contents.length === 1) {
+      tile.content = contents[0];
+      delete tile.contents;
+    } else {
+      delete tile.content;
+      tile.contents = contents;
+    }
+  }
+
+  /**
    * Obtains the content URIs from the given tile.
    *
    * This will either return a single-element array, when the tile
@@ -38,7 +62,7 @@ export class Tiles {
    * used. In this case, a warning will be printed, and the `url`
    * will be returned.
    *
-   * @param tile The `Tile`
+   * @param tile - The `Tile`
    * @returns The content URIs
    */
   static getContentUris(tile: Tile): string[] {

--- a/src/traversal/ExplicitTraversedTile.ts
+++ b/src/traversal/ExplicitTraversedTile.ts
@@ -12,6 +12,8 @@ import { Schema } from "../structure/Metadata/Schema";
 
 import { ImplicitTilings } from "../implicitTiling/ImplicitTilings";
 
+import { Tiles } from "../tilesets/Tiles";
+
 /**
  * An implementation of a `TraversedTile` that reflects a tile
  * that actually appears as a JSON representation in the tileset.
@@ -142,22 +144,19 @@ export class ExplicitTraversedTile implements TraversedTile {
   asFinalTile(): Tile {
     const tile = this._tile;
 
-    const contents = this.getFinalContents();
-
     const finalTile = {
       boundingVolume: tile.boundingVolume,
       viewerRequestVolume: tile.viewerRequestVolume,
       geometricError: tile.geometricError,
       refine: tile.refine,
       transform: tile.transform,
-      content: undefined,
-      contents: contents,
       children: tile.children,
       metadata: tile.metadata,
       implicitTiling: tile.implicitTiling,
       extensions: tile.extensions,
       extras: tile.extras,
     };
+    Tiles.setContents(finalTile, this.getFinalContents());
 
     const schema = this._schema;
     if (schema) {

--- a/src/traversal/ImplicitTraversedTile.ts
+++ b/src/traversal/ImplicitTraversedTile.ts
@@ -18,6 +18,8 @@ import { ImplicitTilings } from "../implicitTiling/ImplicitTilings";
 import { BoundingVolumeDerivation } from "./cesium/BoundingVolumeDerivation";
 import { MetadataSemanticOverrides } from "./MetadataSemanticOverrides";
 
+import { Tiles } from "../tilesets/Tiles";
+
 /**
  * An implementation of a `TraversedTile` that represents a tile
  * within an implicit tileset during its traversal.
@@ -126,29 +128,30 @@ export class ImplicitTraversedTile implements TraversedTile {
     const refine = rootTile.refine;
     const transform = undefined;
     const metadata = undefined;
-    const contents = this.getRawContents();
     const implicitTiling = undefined;
     const extensions = undefined;
     const extras = undefined;
 
-    return {
+    const tile = {
       boundingVolume: boundingVolume,
       viewerRequestVolume: viewerRequestVolume,
       geometricError: geometricError,
       refine: refine,
       transform: transform,
       metadata: metadata,
-      contents: contents,
       implicitTiling: implicitTiling,
       extensions: extensions,
       extras: extras,
     };
+    Tiles.setContents(tile, this.getRawContents());
+    return tile;
   }
 
   /** {@inheritDoc TraversedTile.asFinalTile} */
   asFinalTile(): Tile {
     const tile = this.asRawTile();
-    tile.contents = this.getFinalContents();
+    Tiles.setContents(tile, this.getFinalContents());
+
     const subtreeMetadataModel = this._subtreeModel.subtreeMetadataModel;
     if (subtreeMetadataModel) {
       const tileIndex = this._localCoordinate.toIndex();


### PR DESCRIPTION
There are several operations that (vaguely) do something with tile content. The tile content may either be a single `tile.content` object, or an array, as `tile.contents`. The `TraversedTile` interface tries to hide this difference: It has a single method `getRawContents` that always returns an array (that may also be an empty or single-element array). 

Until now, when obtaining the "_JSON_ representation" of the `Tile` object from a `TraversedTile` (via `asRawTile` or `asFinalTile`), then this JSON object contained a `contents` array, even when there only was a single content.   

With this PR, this is changed: The tile object should have a `content` when there is only one content, and use the `contents` _only_ when there really are multiple contents.

Fixes https://github.com/CesiumGS/3d-tiles-tools/issues/37 

---

An aside: The `TraversedTile` has `getRawContents` and `getFinalContents` methods, both always returning an array. This latter is the one that returns the contents _after_ the semantic overrides have been applied. I'm not perfectly happy with these _two_ methods, and that might be refactored at some point. But there certainly shouldn't be `getRawContent`, `getRawContents`, `getFinalContent`, and `getFinalContents` methods that have to be called by clients in order to figure out whether there are _zero_, _one_ or _multiple_ contents. Right now, clients can just call `for (const content of t.getRawContents()) doSomethingWith(content);`, which is a tad more convenient.

