### PR TITLE
Generalized content processing with external libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,18 @@
     "3d-tiles-tools": "./build/main"
   },
   "dependencies": {
+    "@gltf-transform/core": "^3.2.1",
+    "@gltf-transform/extensions": "^3.2.1",
+    "@gltf-transform/functions": "^3.2.1",
     "archiver": "^5.3.1",
     "better-sqlite3": "^8.0.1",
     "cesium": "^1.103.0",
+    "draco3dgltf": "^1.5.6",
     "gltf-pipeline": "^4.1.0",
     "minimist": "^1.2.7",
     "node-stream-zip": "^1.15.0",
     "seedrandom": "^3.0.5",
+    "sharp": "^0.32.1",
     "yargs": "^17.5.1"
   },
   "devDependencies": {
@@ -40,6 +45,7 @@
     "@microsoft/api-extractor": "^7.33.6",
     "@types/archiver": "^5.3.1",
     "@types/better-sqlite3": "^7.6.2",
+    "@types/draco3dgltf": "^1.4.0",
     "@types/jasmine": "^4.0.3",
     "@types/minimist": "^1.2.2",
     "@types/seedrandom": "^3.0.2",

--- a/src/tilesetProcessing/TileContentProcessing.ts
+++ b/src/tilesetProcessing/TileContentProcessing.ts
@@ -1,0 +1,38 @@
+import { TilesetEntry } from "../tilesetData/TilesetEntry";
+
+import { BasicTilesetProcessor } from "./BasicTilesetProcessor";
+import { TileContentProcessor } from "./TileContentProcessor";
+
+export class TileContentProcessing {
+  static async process(
+    tilesetSourceName: string,
+    tilesetTargetName: string,
+    overwrite: boolean,
+    tileContentProcessor: TileContentProcessor
+  ) {
+    const quiet = false;
+    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    await tilesetProcessor.begin(
+      tilesetSourceName,
+      tilesetTargetName,
+      overwrite
+    );
+
+    const entryProcessor = async (
+      sourceEntry: TilesetEntry,
+      type: string | undefined
+    ) => {
+      const targetValue = await tileContentProcessor(type, sourceEntry.value);
+      const targetEntry = {
+        key: sourceEntry.key,
+        value: targetValue,
+      };
+      return targetEntry;
+    };
+    await tilesetProcessor.processTileContentEntries(
+      (uri: string) => uri,
+      entryProcessor
+    );
+    await tilesetProcessor.end();
+  }
+}

--- a/src/tilesetProcessing/TileContentProcessor.ts
+++ b/src/tilesetProcessing/TileContentProcessor.ts
@@ -1,0 +1,4 @@
+export type TileContentProcessor = (
+  type: string | undefined,
+  content: Buffer
+) => Promise<Buffer>;

--- a/src/tilesetProcessing/TileContentProcessors.ts
+++ b/src/tilesetProcessing/TileContentProcessors.ts
@@ -1,0 +1,22 @@
+import { TileContentProcessor } from "./TileContentProcessor";
+
+export class TileContentProcessors {
+  static concat(
+    ...tileContentProcessors: TileContentProcessor[]
+  ): TileContentProcessor {
+    const result = async (
+      type: string | undefined,
+      inputContentData: Buffer
+    ) => {
+      let currentContentData = inputContentData;
+      for (const tileContentProcessor of tileContentProcessors) {
+        currentContentData = await tileContentProcessor(
+          type,
+          currentContentData
+        );
+      }
+      return currentContentData;
+    };
+    return result;
+  }
+}

--- a/src/tilesetProcessing/TileContentProcessorsGltfPipeline.ts
+++ b/src/tilesetProcessing/TileContentProcessorsGltfPipeline.ts
@@ -1,0 +1,20 @@
+import GltfPipeline from "gltf-pipeline";
+
+import { ContentDataTypes } from "../contentTypes/ContentDataTypes";
+import { TileContentProcessor } from "./TileContentProcessor";
+
+export class TileContentProcessorsGltfPipeline {
+  static create(options: any): TileContentProcessor {
+    const tileContentProcessor = async (
+      type: string | undefined,
+      inputContentData: Buffer
+    ) => {
+      if (type !== ContentDataTypes.CONTENT_TYPE_GLB) {
+        return inputContentData;
+      }
+      const result = await GltfPipeline.processGlb(inputContentData, options);
+      return result.glb;
+    };
+    return tileContentProcessor;
+  }
+}

--- a/src/tilesetProcessing/TileContentProcessorsGltfTransform.ts
+++ b/src/tilesetProcessing/TileContentProcessorsGltfTransform.ts
@@ -1,0 +1,49 @@
+import { NodeIO, Transform } from "@gltf-transform/core";
+import { KHRONOS_EXTENSIONS } from "@gltf-transform/extensions";
+import draco3d from "draco3dgltf";
+
+import { ContentDataTypes } from "../contentTypes/ContentDataTypes";
+import { TileContentProcessor } from "./TileContentProcessor";
+
+export class TileContentProcessorsGltfTransform {
+  private static io: NodeIO | undefined;
+
+  private static async getIO(): Promise<NodeIO> {
+    if (TileContentProcessorsGltfTransform.io) {
+      return TileContentProcessorsGltfTransform.io;
+    }
+    const io = new NodeIO();
+    io.registerExtensions(KHRONOS_EXTENSIONS).registerDependencies({
+      "draco3d.decoder": await draco3d.createDecoderModule(),
+      "draco3d.encoder": await draco3d.createEncoderModule(),
+    });
+    TileContentProcessorsGltfTransform.io = io;
+    return io;
+  }
+
+  static create(...transforms: Transform[]): TileContentProcessor {
+    const gltfTransformCall =
+      TileContentProcessorsGltfTransform.createGltfTransformCall(...transforms);
+    return async (
+      type: string | undefined,
+      inputContentData: Buffer
+    ): Promise<Buffer> => {
+      if (type !== ContentDataTypes.CONTENT_TYPE_GLB) {
+        return inputContentData;
+      }
+      return gltfTransformCall(inputContentData);
+    };
+  }
+
+  private static createGltfTransformCall(
+    ...transforms: Transform[]
+  ): (inputGlb: Buffer) => Promise<Buffer> {
+    return async (inputGlb: Buffer): Promise<Buffer> => {
+      const io = await TileContentProcessorsGltfTransform.getIO();
+      const document = await io.readBinary(inputGlb);
+      await document.transform(...transforms);
+      const outputGlb = await io.writeBinary(document);
+      return Buffer.from(outputGlb);
+    };
+  }
+}


### PR DESCRIPTION
A common task for processing tilesets is: "Apply a certain operation to every tile content". Some distinctions here are whether this operation changes the name (`content.uri`) of the tile content or not, whether it can "remove/delete" the content or not, or whether it has to apply special handling depending on the _type_ of the content data, or whether it requires additional information (configuration options) at runtime.

There already are some structures that support all these considerations. But a frequent pattern is that all these specific questions do not matter (or are inherently answered). 

One example is when `optimizeGlb` is called on all GLB contents of a tileset: It does not change URIs. It always operates on GLB data. It just runs `gltf-pipeline` on all contents, and does whatever `gltf-pipeline` does. 

Other operations could fit into this simple pattern as well. For example, integrating `meshoptimizer` to support meshopt compression. Or operations that modify the textures inside a glTF. Or ... running `gltf-transform`, which is basically a combination of all the above: It allows compression, texture manipulation, or other operations on GLB data. But it always follows the pattern "GLB in - GLB out". 

This PR adds some convenience classes that allow an easier integration of libraries like that (and uses `gltf-pipeline` and `gltf-transform` for now). 

A **draft** usage example is shown here: It applies a set of operations to each (GLB) tile content:

- Use `gltf-transform` to...
  - prune unused elements
  - deduplicate elements
  - (apply draco compression - for tests, commented out here)
  - apply a texture resizing/compression (delegating to the `sharp` library)
- Then use `gltf-pipeline` to apply draco compression
 
```JavaScript
import {
  prune,
  dedup,
  draco,
  textureCompress,
} from "@gltf-transform/functions";
import sharp from "sharp";

import { TileContentProcessing } from "./src/tilesetProcessing/TileContentProcessing";
import { TileContentProcessors } from "./src/tilesetProcessing/TileContentProcessors";
import { TileContentProcessorsGltfTransform } from "./src/tilesetProcessing/TileContentProcessorsGltfTransform";
import { TileContentProcessorsGltfPipeline } from "./src/tilesetProcessing/TileContentProcessorsGltfPipeline";

async function runTest() {
  const tilesetSourceName = "./input/TestTileset";
  const tilesetTargetName = "./output/TestTileset";
  const overwrite = true;

  // Some `Transform` instances that describe operations
  // that are executed with `gltf-transform`
  const transformDraco = draco({
    method: "edgebreaker",
    encodeSpeed: 5,
    decodeSpeed: 5,
    quantizeGeneric: 10,
  });
  const transformTextures = textureCompress({
    encoder: sharp,
    targetFormat: "jpeg",
    quality: 70,
    resize: [512, 512],
  });

  // Create a `TileContentProcessor` that applies
  // some transforms with `gltf-transform`
  const tileContentProcessorGltfTransform =
    TileContentProcessorsGltfTransform.create(
      dedup(),
      prune(),
      //transformDraco,
      transformTextures
    );

  // Create a `TileContentProcessor` that applies
  // `gltf-pipeline` with the given options
  const gltfPipleineOptions = {
    dracoOptions: {
      compressionLevel: 10,
    },
  };
  const tileContentProcessorGltfPipeline =
    TileContentProcessorsGltfPipeline.create(gltfPipleineOptions);

  // Combine several `TileContentProcessor` instances
  // into one
  const tileContentProcessor = TileContentProcessors.concat(
    tileContentProcessorGltfTransform,
    tileContentProcessorGltfPipeline
  );

  // Process the tileset source, and write it to the tileset target,
  // applying each `TileContentProcessor` to all tile contents
  await TileContentProcessing.process(
    tilesetSourceName,
    tilesetTargetName,
    overwrite,
    tileContentProcessor
  );
}

runTest();
```

Many of the structures may still change, but this may already be close to the pseudocode of
```
processTileContent(input, {
  doThis(),
  doThat(withOptions),
  thenDoAnotherThing()
});
```
with some flexibility for what is actually _done_ with the tile content data.

There's still the caveat that this is currently only possible **in code**: There is not yet a sensible `pipeline.json` representation of all that. Parts of this could easily be mapped to _specific_ pipeline JSON representations. The question then is: How specific can this JSON representation be? (It should, for example, not "know" that a texture resize is done with `gltf-transform` that delegates to the `sharp` library...)
