### PR TITLE
Apply RTC_CENTER from tile data to GLB

### DIFF
--- a/specs/ContentOpsSpec.ts
+++ b/specs/ContentOpsSpec.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import { Buffers } from "../src/base/Buffers";
+
+import { ContentOps } from "../src/contentProcessing/ContentOps";
+import { SpecHelpers } from "./SpecHelpers";
+
+describe("ContentOps", function () {
+  it("extracts a single GLB buffers from B3DM", async function () {
+    const p = "./specs/data/contentTypes/content.b3dm";
+    const tileDataBuffer = fs.readFileSync(p);
+
+    const glbBuffers = await ContentOps.extractGlbBuffers(tileDataBuffer);
+    expect(glbBuffers.length).toBe(1);
+  });
+
+  it("extracts multiple GLB buffers from CMPT", async function () {
+    const p = "./specs/data/contentTypes/content.cmpt";
+    const tileDataBuffer = fs.readFileSync(p);
+
+    const glbBuffers = await ContentOps.extractGlbBuffers(tileDataBuffer);
+    expect(glbBuffers.length).toBe(2);
+  });
+
+  it("extracts no GLB buffers from PNTS", async function () {
+    const p = "./specs/data/contentTypes/content.pnts";
+    const tileDataBuffer = fs.readFileSync(p);
+
+    const glbBuffers = await ContentOps.extractGlbBuffers(tileDataBuffer);
+    expect(glbBuffers.length).toBe(0);
+  });
+});

--- a/specs/TileFormatsSpec.ts
+++ b/specs/TileFormatsSpec.ts
@@ -115,30 +115,6 @@ describe("TileFormats", function () {
     expect(tileData.innerTileBuffers.length).toBe(2);
   });
 
-  it("extracts a single GLB buffers from B3DM", function () {
-    const p = "./specs/data/contentTypes/content.b3dm";
-    const tileDataBuffer = fs.readFileSync(p);
-
-    const glbBuffers = TileFormats.extractGlbBuffers(tileDataBuffer);
-    expect(glbBuffers.length).toBe(1);
-  });
-
-  it("extracts multiple GLB buffers from CMPT", function () {
-    const p = "./specs/data/contentTypes/content.cmpt";
-    const tileDataBuffer = fs.readFileSync(p);
-
-    const glbBuffers = TileFormats.extractGlbBuffers(tileDataBuffer);
-    expect(glbBuffers.length).toBe(2);
-  });
-
-  it("extracts no GLB buffers from PNTS", function () {
-    const p = "./specs/data/contentTypes/content.pnts";
-    const tileDataBuffer = fs.readFileSync(p);
-
-    const glbBuffers = TileFormats.extractGlbBuffers(tileDataBuffer);
-    expect(glbBuffers.length).toBe(0);
-  });
-
   it("throws an error when trying to read tile data from a buffer that does not contain B3DM, I3DM, or PNTS", function () {
     const p = "./specs/data/contentTypes/content.cmpt";
     const tileDataBuffer = fs.readFileSync(p);

--- a/src/ToolsMain.ts
+++ b/src/ToolsMain.ts
@@ -41,8 +41,7 @@ export class ToolsMain {
   static async b3dmToGlb(input: string, output: string, force: boolean) {
     ToolsMain.ensureCanWrite(output, force);
     const inputBuffer = fs.readFileSync(input);
-    const inputTileData = TileFormats.readTileData(inputBuffer);
-    const outputBuffer = inputTileData.payload;
+    const outputBuffer = await ContentOps.b3dmToGlbBuffer(inputBuffer);
     const upgradedOutputBuffer = await GltfUtilities.upgradeGlb(
       outputBuffer,
       undefined
@@ -54,7 +53,7 @@ export class ToolsMain {
   }
   static async cmptToGlb(input: string, output: string, force: boolean) {
     const inputBuffer = fs.readFileSync(input);
-    const glbBuffers = TileFormats.extractGlbBuffers(inputBuffer);
+    const glbBuffers = await ContentOps.extractGlbBuffers(inputBuffer);
     const glbsLength = glbBuffers.length;
     const glbPaths = new Array(glbsLength);
     if (glbsLength === 0) {
@@ -81,17 +80,13 @@ export class ToolsMain {
   static async glbToB3dm(input: string, output: string, force: boolean) {
     ToolsMain.ensureCanWrite(output, force);
     const inputBuffer = fs.readFileSync(input);
-    const outputTileData =
-      TileFormats.createDefaultB3dmTileDataFromGlb(inputBuffer);
-    const outputBuffer = TileFormats.createTileDataBuffer(outputTileData);
+    const outputBuffer = ContentOps.glbToB3dmBuffer(inputBuffer);
     fs.writeFileSync(output, outputBuffer);
   }
   static async glbToI3dm(input: string, output: string, force: boolean) {
     ToolsMain.ensureCanWrite(output, force);
     const inputBuffer = fs.readFileSync(input);
-    const outputTileData =
-      TileFormats.createDefaultI3dmTileDataFromGlb(inputBuffer);
-    const outputBuffer = TileFormats.createTileDataBuffer(outputTileData);
+    const outputBuffer = ContentOps.glbToI3dmBuffer(inputBuffer);
     fs.writeFileSync(output, outputBuffer);
   }
   static async optimizeB3dm(

--- a/src/contentProcessing/GtlfUtilities.ts
+++ b/src/contentProcessing/GtlfUtilities.ts
@@ -179,6 +179,22 @@ export class GltfUtilities {
       return;
     }
     const rtcTranslation = rtcExtension.center;
+    GltfUtilities.insertRootWithTranslation(gltf, rtcTranslation);
+    Extensions.removeExtensionUsed(gltf, "CESIUM_RTC");
+    Extensions.removeExtension(gltf, "CESIUM_RTC");
+  }
+
+  /**
+   * Inserts new root nodes into the given glTF, with the given translation.
+   *
+   * This will insert a new parent node above each node in the `scenes`
+   * array. The new nodes will be added at the end of the `nodes` array,
+   * so that the indices of existing nodes remain unchanged.
+   *
+   * @param gltf - The glTF JSON object
+   * @param translation The translation as a 3D array
+   */
+  static insertRootWithTranslation(gltf: any, translation: number[]) {
     const scenes = gltf.scenes;
     if (!scenes) {
       return;
@@ -189,7 +205,7 @@ export class GltfUtilities {
         for (let i = 0; i < sceneNodes.length; i++) {
           const nodeIndex = sceneNodes[i];
           const newParent = {
-            translation: rtcTranslation,
+            translation: translation,
             children: [nodeIndex],
           };
           const newParentIndex = gltf.nodes.length;
@@ -198,7 +214,5 @@ export class GltfUtilities {
         }
       }
     }
-    Extensions.removeExtensionUsed(gltf, "CESIUM_RTC");
-    Extensions.removeExtension(gltf, "CESIUM_RTC");
   }
 }

--- a/src/pipelines/ContentStageExecutor.ts
+++ b/src/pipelines/ContentStageExecutor.ts
@@ -1,4 +1,5 @@
 import path from "path";
+
 import GltfPipeline from "gltf-pipeline";
 
 import { Paths } from "../base/Paths";
@@ -222,9 +223,11 @@ export class ContentStageExecutor {
       if (type !== ContentDataTypes.CONTENT_TYPE_B3DM) {
         return sourceEntry;
       }
+      const tileDataBufer = sourceEntry.value;
+      const glbBuffer = await ContentOps.b3dmToGlbBuffer(tileDataBufer);
       const targetEntry = {
         key: uriProcessor(sourceEntry.key),
-        value: ContentOps.b3dmToGlbBuffer(sourceEntry.value),
+        value: glbBuffer,
       };
       return targetEntry;
     };
@@ -271,9 +274,11 @@ export class ContentStageExecutor {
       if (type !== ContentDataTypes.CONTENT_TYPE_I3DM) {
         return sourceEntry;
       }
+      const tileDataBufer = sourceEntry.value;
+      const glbBuffer = await ContentOps.i3dmToGlbBuffer(tileDataBufer);
       const targetEntry = {
         key: uriProcessor(sourceEntry.key),
-        value: ContentOps.i3dmToGlbBuffer(sourceEntry.value),
+        value: glbBuffer,
       };
       return targetEntry;
     };

--- a/src/tileFormats/TileFormats.ts
+++ b/src/tileFormats/TileFormats.ts
@@ -200,52 +200,6 @@ export class TileFormats {
   }
 
   /**
-   * Convenience method to collect all GLB (binary glTF) buffers from
-   * the given tile data.
-   *
-   * This can be applied to B3DM and I3DM tile data, as well as CMPT
-   * tile data. (For PNTS, it will return an empty array). When the
-   * given tile data is a composite (CMPT) tile data, and recursively
-   * collect the buffer from its inner tiles.
-   *
-   * @param tileDataBuffer - The tile data buffer
-   * @returns The array of GLB buffers
-   */
-  static extractGlbBuffers(tileDataBuffer: Buffer): Buffer[] {
-    const glbBuffers: Buffer[] = [];
-    TileFormats.extractGlbBuffersInternal(tileDataBuffer, glbBuffers);
-    return glbBuffers;
-  }
-
-  /**
-   * Implementation for `extractGlbBuffers`, called recursively.
-   *
-   * @param tileDataBuffer - The tile data buffer
-   * @param glbBuffers The array of GLB buffers
-   */
-  private static extractGlbBuffersInternal(
-    tileDataBuffer: Buffer,
-    glbBuffers: Buffer[]
-  ): void {
-    const isComposite = TileFormats.isComposite(tileDataBuffer);
-    if (isComposite) {
-      const compositeTileData =
-        TileFormats.readCompositeTileData(tileDataBuffer);
-      for (const innerTileDataBuffer of compositeTileData.innerTileBuffers) {
-        TileFormats.extractGlbBuffersInternal(innerTileDataBuffer, glbBuffers);
-      }
-    } else {
-      const tileData = TileFormats.readTileData(tileDataBuffer);
-      if (
-        tileData.header.magic === "b3dm" ||
-        tileData.header.magic === "i3dm"
-      ) {
-        glbBuffers.push(tileData.payload);
-      }
-    }
-  }
-
-  /**
    * Creates a Batched 3D Model (B3DM) `TileData` instance from
    * a buffer that is assumed to contain valid binary glTF (GLB)
    * data.


### PR DESCRIPTION
The `b3dmToGlb` and `i3dmToGlb` operations until now only extracted the GLB payload from the tile data. The resulting GLB did not take into account any `RTC_CENTER` that may have been defined in the feature table of the input data.

This PR changes that: When there is an `RTC_CENTER` in the feature table, then this will cause new root nodes to be inserted into the GLB, which have the `RTC_CENTER` as their `translation` (taking the y-up-to-z-up transform into account). 

Some details to be decided:

**1.** Should applying the RTC_CENTER **always** be done? 

The `b3dmToGlb` and `i3dmToGlb` can either be used as content stages in a pipeline, or used as "standalone" commands from the command line. I currently assume that the RTC_CENTER should **always** be applied, but wonder whether someone might want an option to only extract the GLB, without applying the `RTC_CENTER`. Something like this could be offered with an option, e.g. by having a `-applyRtc=true/false` command line option that is `true` by default...

**2.** Should applying the `RTC_CENTER` also be done when extracting the (multiple) GLBs from a CMPT? 

The `cmptToGlb` command line operation takes one CMPT, and extracts **all** GLBs (recursively through other CMPTs or I3DMs or B3DMs). I assume that the results should also include the `RTC_CENTER` for now.

