### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-### x.x.x - yyyy-mm-dd
+### 0.3.0 - 2023-08-30
 
 - Transparently decompress entries in `3tz` files when they are compressed with `DEFLATE` (via [#55](https://github.com/CesiumGS/3d-tiles-tools/pull/55))
   - The exact behavior in terms of entry compression is not specified yet. This is tracked in [#56](https://github.com/CesiumGS/3d-tiles-tools/issues/56)

--- a/etc/3d-tiles-tools.api.md
+++ b/etc/3d-tiles-tools.api.md
@@ -22,6 +22,8 @@ export class ArchiveFunctions3tz {
     // (undocumented)
     static readZipIndex(fd: number): IndexEntry[];
     // (undocumented)
+    static readZipLocalFileHeader(fd: number, offset: number | bigint, path: string): ZipLocalFileHeader;
+    // (undocumented)
     static zipIndexFind(zipIndex: IndexEntry[], searchHash: Buffer): number;
 }
 
@@ -947,6 +949,20 @@ export class UnzippingResourceResolver implements ResourceResolver {
 export class Uris {
     static isAbsoluteUri(uri: string): boolean;
     static isDataUri(uri: string): boolean;
+}
+
+// @internal (undocumented)
+export interface ZipLocalFileHeader {
+    // (undocumented)
+    comp_size: number;
+    // (undocumented)
+    compression_method: number;
+    // (undocumented)
+    extra_size: number;
+    // (undocumented)
+    filename_size: number;
+    // (undocumented)
+    signature: number;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3d-tiles-tools",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "description": "3D Tiles tools",
   "author": {


### PR DESCRIPTION
(Most of the preparation had already been done in https://github.com/CesiumGS/3d-tiles-tools/pull/57 )

- Updated package.json
- Updated CHANGES.md
- Updated auto-generated API documentation
