### PR TITLE
Fix default log levels

### DIFF
--- a/src/logging/Loggers.ts
+++ b/src/logging/Loggers.ts
@@ -32,9 +32,13 @@ export class Loggers {
     prettyPrint?: boolean,
     logFilePath?: string
   ): Logger {
-    const consoleLogLevel = "info";
+    // The default log level for the logger itself, which determines
+    // up to which level messages will be sent to the targets.
+    const globalLogLevel = "info";
+
+    // The log levels for the individual targets.
+    const consoleLogLevel = "trace";
     const fileLogLevel = "trace";
-    const globalLogLevel = "trace";
 
     const transportTargetOptionsList: TransportTargetOptions[] = [];
 


### PR DESCRIPTION
The default log levels had been wrong, limiting the level that could be used for the console to `info`.

- The `globalLogLevel` is the level that the logger itself uses
- The `consoleLogLevel` and `fileLogLevel` can be imagined as additional "filters" that are applied "behind the logger"

So previously, the level for the console target was
`const consoleLogLevel = "info";`
_and this value cannot be changed_. So even when the logger was set to `trace` afterwards, the console still displayed nothing more than `info`.

