### PR TITLE
Updates for glTF extension validation

### DIFF
--- a/specs/metadata/MetadataEntityModelSpec.ts
+++ b/specs/metadata/MetadataEntityModelSpec.ts
@@ -13,11 +13,13 @@ describe("metadata/MetadataEntityModel", function () {
       const testMetadataClass: MetadataClass = {
         properties: {},
       };
+      const testMetadataEnums = {};
       const entityJson = {
         testProperty: 1234,
       };
       const entity = MetadataEntityModels.createFromClass(
         testMetadataClass,
+        testMetadataEnums,
         entityJson
       );
       entity.getPropertyValue("testProperty");
@@ -34,11 +36,13 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: undefined,
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -56,15 +60,67 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: 2345,
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
     expect(value).toBe(1234);
+  });
+
+  it("obtains a default value for an enum noData value", function () {
+    const testMetadataClass: MetadataClass = {
+      properties: {
+        testProperty: {
+          type: "ENUM",
+          enumType: "testEnum",
+          noData: "TEST_NO_DATA_ENUM_VALUE",
+          default: "TEST_DEFAULT_ENUM_VALUE",
+        },
+      },
+    };
+    const testMetadataEnums = {
+      testEnum: {
+        valueType: "UINT8",
+        values: [
+          {
+            name: "TEST_NO_DATA_ENUM_VALUE",
+            value: 255,
+          },
+          {
+            name: "TEST_ENUM_VALUE_A",
+            value: 1,
+          },
+          {
+            name: "TEST_ENUM_VALUE_B",
+            value: 2,
+          },
+          {
+            name: "TEST_ENUM_VALUE_C",
+            value: 3,
+          },
+          {
+            name: "TEST_DEFAULT_ENUM_VALUE",
+            value: 4,
+          },
+        ],
+      },
+    };
+    const entityJson = {
+      testProperty: "TEST_NO_DATA_ENUM_VALUE",
+    };
+    const entity = MetadataEntityModels.createFromClass(
+      testMetadataClass,
+      testMetadataEnums,
+      entityJson
+    );
+    const value = entity.getPropertyValue("testProperty");
+    expect(value).toBe("TEST_DEFAULT_ENUM_VALUE");
   });
 
   it("obtains a value for a vec3 float32 value with offset in property definition", function () {
@@ -77,11 +133,13 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -99,11 +157,13 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -122,11 +182,13 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -148,8 +210,10 @@ describe("metadata/MetadataEntityModel", function () {
       testProperty: [3.0, 4.0, 5.0],
       scale: [2.0, 3.0, 4.0],
     };
+    const testMetadataEnums = {};
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -167,12 +231,14 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
       offset: [1.0, 2.0, 3.0],
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -190,12 +256,14 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
       offset: [1.0, 2.0, 3.0],
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -213,12 +281,14 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
       scale: [2.0, 3.0, 4.0],
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");
@@ -237,6 +307,7 @@ describe("metadata/MetadataEntityModel", function () {
         },
       },
     };
+    const testMetadataEnums = {};
     const entityJson = {
       testProperty: [3.0, 4.0, 5.0],
       offset: [1.0, 2.0, 3.0],
@@ -244,6 +315,7 @@ describe("metadata/MetadataEntityModel", function () {
     };
     const entity = MetadataEntityModels.createFromClass(
       testMetadataClass,
+      testMetadataEnums,
       entityJson
     );
     const value = entity.getPropertyValue("testProperty");

--- a/specs/metadata/PropertyTableModelsSpec.ts
+++ b/specs/metadata/PropertyTableModelsSpec.ts
@@ -16,7 +16,7 @@ import { ClassProperty } from "../../src/structure/Metadata/ClassProperty";
  * - They check whether the elements of the input data and the
  *   values from the entity model are generically equal.
  */
-describe("metadata/PropertyTableModelSpec", function () {
+describe("metadata/PropertyTableModelsSpec", function () {
   const epsilon = 0.000001;
 
   it("correctly represents example_INT16_SCALAR", function () {

--- a/specs/metadata/PropertyTableModelsSpecialValuesSpec.ts
+++ b/specs/metadata/PropertyTableModelsSpecialValuesSpec.ts
@@ -1,0 +1,288 @@
+import { genericEquals } from "./genericEquals";
+
+import { BinaryPropertyTables } from "../../src/metadata/binary/BinaryPropertyTables";
+import { BinaryPropertyTableModel } from "../../src/metadata/binary/BinaryPropertyTableModel";
+
+import { ClassProperty } from "../../src/structure/Metadata/ClassProperty";
+import { MetadataEnum } from "../../src/structure/Metadata/MetadataEnum";
+
+/**
+ * Test for handling "special" values (namely, `noData` and `default`)
+ * in the `PropertyTableModels` class.
+ */
+describe("metadata/PropertyTableModelSpecialValuesSpec", function () {
+  const epsilon = 0.000001;
+
+  it("correctly represents example_ENUM", function () {
+    const example_ENUM: ClassProperty = {
+      type: "ENUM",
+      enumType: "testMetadataEnum",
+    };
+    const example_ENUM_values = ["TEST_ENUM_VALUE_A", "TEST_ENUM_VALUE_B"];
+
+    const testMetadataEnum: MetadataEnum = {
+      name: "testMetadataEnum",
+      valueType: "UINT8",
+      values: [
+        {
+          name: "TEST_NO_DATA_ENUM_VALUE",
+          value: 255,
+        },
+        {
+          name: "TEST_ENUM_VALUE_A",
+          value: 1,
+        },
+        {
+          name: "TEST_ENUM_VALUE_B",
+          value: 2,
+        },
+        {
+          name: "TEST_ENUM_VALUE_C",
+          value: 3,
+        },
+        {
+          name: "TEST_DEFAULT_ENUM_VALUE",
+          value: 4,
+        },
+      ],
+    };
+
+    const classProperty = example_ENUM;
+    const values = example_ENUM_values;
+
+    const arrayOffsetType = "UINT32";
+    const stringOffsetType = "UINT32";
+    const binaryPropertyTable =
+      BinaryPropertyTables.createBinaryPropertyTableFromProperty(
+        "testProperty",
+        classProperty,
+        values,
+        arrayOffsetType,
+        stringOffsetType,
+        testMetadataEnum
+      );
+    const propertyTableModel = new BinaryPropertyTableModel(
+      binaryPropertyTable
+    );
+    const count = values.length;
+    for (let i = 0; i < count; i++) {
+      const entity = propertyTableModel.getMetadataEntityModel(i);
+      const expected = values[i];
+      const actual = entity.getPropertyValue("testProperty");
+      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
+    }
+  });
+
+  it("correctly represents example_ENUM with noData and default values", function () {
+    const example_ENUM: ClassProperty = {
+      type: "ENUM",
+      enumType: "testMetadataEnum",
+      noData: "TEST_NO_DATA_ENUM_VALUE",
+      default: "TEST_DEFAULT_ENUM_VALUE",
+    };
+
+    // The "noData" value is expected to be translated
+    // into the "default" value
+    const example_ENUM_values = [
+      "TEST_NO_DATA_ENUM_VALUE",
+      "TEST_ENUM_VALUE_B",
+    ];
+    const expected_example_ENUM_values = [
+      "TEST_DEFAULT_ENUM_VALUE",
+      "TEST_ENUM_VALUE_B",
+    ];
+
+    const testMetadataEnum: MetadataEnum = {
+      name: "testMetadataEnum",
+      valueType: "UINT8",
+      values: [
+        {
+          name: "TEST_NO_DATA_ENUM_VALUE",
+          value: 255,
+        },
+        {
+          name: "TEST_ENUM_VALUE_A",
+          value: 1,
+        },
+        {
+          name: "TEST_ENUM_VALUE_B",
+          value: 2,
+        },
+        {
+          name: "TEST_ENUM_VALUE_C",
+          value: 3,
+        },
+        {
+          name: "TEST_DEFAULT_ENUM_VALUE",
+          value: 4,
+        },
+      ],
+    };
+
+    const classProperty = example_ENUM;
+    const values = example_ENUM_values;
+    const expectedValues = expected_example_ENUM_values;
+
+    const arrayOffsetType = "UINT32";
+    const stringOffsetType = "UINT32";
+    const binaryPropertyTable =
+      BinaryPropertyTables.createBinaryPropertyTableFromProperty(
+        "testProperty",
+        classProperty,
+        values,
+        arrayOffsetType,
+        stringOffsetType,
+        testMetadataEnum
+      );
+    const propertyTableModel = new BinaryPropertyTableModel(
+      binaryPropertyTable
+    );
+    const count = values.length;
+    for (let i = 0; i < count; i++) {
+      const entity = propertyTableModel.getMetadataEntityModel(i);
+      const expected = expectedValues[i];
+      const actual = entity.getPropertyValue("testProperty");
+      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
+    }
+  });
+
+  it("correctly represents example_fixed_length_ENUM_array", function () {
+    const example_fixed_length_ENUM_array: ClassProperty = {
+      type: "ENUM",
+      enumType: "testMetadataEnum",
+      array: true,
+      count: 2,
+    };
+    const example_fixed_length_ENUM_array_values = [
+      ["TEST_ENUM_VALUE_A", "TEST_ENUM_VALUE_B"],
+      ["TEST_ENUM_VALUE_B", "TEST_ENUM_VALUE_C"],
+    ];
+
+    const testMetadataEnum: MetadataEnum = {
+      name: "testMetadataEnum",
+      valueType: "UINT8",
+      values: [
+        {
+          name: "TEST_NO_DATA_ENUM_VALUE",
+          value: 255,
+        },
+        {
+          name: "TEST_ENUM_VALUE_A",
+          value: 1,
+        },
+        {
+          name: "TEST_ENUM_VALUE_B",
+          value: 2,
+        },
+        {
+          name: "TEST_ENUM_VALUE_C",
+          value: 3,
+        },
+        {
+          name: "TEST_DEFAULT_ENUM_VALUE",
+          value: 4,
+        },
+      ],
+    };
+
+    const classProperty = example_fixed_length_ENUM_array;
+    const values = example_fixed_length_ENUM_array_values;
+
+    const arrayOffsetType = "UINT32";
+    const stringOffsetType = "UINT32";
+    const binaryPropertyTable =
+      BinaryPropertyTables.createBinaryPropertyTableFromProperty(
+        "testProperty",
+        classProperty,
+        values,
+        arrayOffsetType,
+        stringOffsetType,
+        testMetadataEnum
+      );
+    const propertyTableModel = new BinaryPropertyTableModel(
+      binaryPropertyTable
+    );
+    const count = values.length;
+    for (let i = 0; i < count; i++) {
+      const entity = propertyTableModel.getMetadataEntityModel(i);
+      const expected = values[i];
+      const actual = entity.getPropertyValue("testProperty");
+      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
+    }
+  });
+
+  it("correctly represents example_fixed_length_ENUM_array with noData and default values", function () {
+    const example_fixed_length_ENUM_array: ClassProperty = {
+      type: "ENUM",
+      enumType: "testMetadataEnum",
+      array: true,
+      count: 2,
+      noData: ["TEST_NO_DATA_ENUM_VALUE", "TEST_NO_DATA_ENUM_VALUE"],
+      default: ["TEST_DEFAULT_ENUM_VALUE", "TEST_DEFAULT_ENUM_VALUE"],
+    };
+
+    // The "noData" value is expected to be translated
+    // into the "default" value
+    const example_fixed_length_ENUM_array_values = [
+      ["TEST_NO_DATA_ENUM_VALUE", "TEST_NO_DATA_ENUM_VALUE"],
+      ["TEST_ENUM_VALUE_A", "TEST_ENUM_VALUE_B"],
+    ];
+    const expected_example_fixed_length_ENUM_array_values = [
+      ["TEST_DEFAULT_ENUM_VALUE", "TEST_DEFAULT_ENUM_VALUE"],
+      ["TEST_ENUM_VALUE_A", "TEST_ENUM_VALUE_B"],
+    ];
+
+    const testMetadataEnum: MetadataEnum = {
+      name: "testMetadataEnum",
+      valueType: "UINT8",
+      values: [
+        {
+          name: "TEST_NO_DATA_ENUM_VALUE",
+          value: 255,
+        },
+        {
+          name: "TEST_ENUM_VALUE_A",
+          value: 1,
+        },
+        {
+          name: "TEST_ENUM_VALUE_B",
+          value: 2,
+        },
+        {
+          name: "TEST_ENUM_VALUE_C",
+          value: 3,
+        },
+        {
+          name: "TEST_DEFAULT_ENUM_VALUE",
+          value: 4,
+        },
+      ],
+    };
+
+    const classProperty = example_fixed_length_ENUM_array;
+    const values = example_fixed_length_ENUM_array_values;
+    const expectedValues = expected_example_fixed_length_ENUM_array_values;
+
+    const arrayOffsetType = "UINT32";
+    const stringOffsetType = "UINT32";
+    const binaryPropertyTable =
+      BinaryPropertyTables.createBinaryPropertyTableFromProperty(
+        "testProperty",
+        classProperty,
+        values,
+        arrayOffsetType,
+        stringOffsetType,
+        testMetadataEnum
+      );
+    const propertyTableModel = new BinaryPropertyTableModel(
+      binaryPropertyTable
+    );
+    const count = values.length;
+    for (let i = 0; i < count; i++) {
+      const entity = propertyTableModel.getMetadataEntityModel(i);
+      const expected = expectedValues[i];
+      const actual = entity.getPropertyValue("testProperty");
+      expect(genericEquals(actual, expected, epsilon)).toBeTrue();
+    }
+  });
+});

--- a/src/contentProcessing/GltfUtilities.ts
+++ b/src/contentProcessing/GltfUtilities.ts
@@ -50,6 +50,149 @@ export class GltfUtilities {
   }
 
   /**
+   * Extract the JSON- and binary part from the given GLB buffer.
+   *
+   * The given buffer may contain glTF 2.0 binary data, or glTF 1.0
+   * binary data.
+   *
+   * Note that this does NOT convert the input data. It only extracts
+   * the data, as-it-is.
+   *
+   * @param glbBuffer - The buffer containing the GLB
+   * @returns The JSON- and binary data buffers
+   * @throws TileFormatError If the input does not contain valid GLB data.
+   */
+  static extractDataFromGlb(glbBuffer: Buffer): {
+    jsonData: Buffer;
+    binData: Buffer;
+  } {
+    const magic = Buffers.getMagicString(glbBuffer);
+    if (magic !== "glTF") {
+      throw new TileFormatError(
+        `Expected magic header to be 'gltf', but found ${magic}`
+      );
+    }
+    if (glbBuffer.length < 12) {
+      throw new TileFormatError(
+        `Expected at least 12 bytes, but only got ${glbBuffer.length}`
+      );
+    }
+    const length = glbBuffer.readUInt32LE(8);
+    if (length > glbBuffer.length) {
+      throw new TileFormatError(
+        `Header indicates ${length} bytes, but input has ${glbBuffer.length} bytes`
+      );
+    }
+    const version = glbBuffer.readUInt32LE(4);
+    if (version === 1) {
+      return GltfUtilities.extractDataFromGlb1(glbBuffer);
+    }
+    if (version === 2) {
+      return GltfUtilities.extractDataFromGlb2(glbBuffer);
+    }
+    throw new TileFormatError(`Expected version 1 or 2, but got ${version}`);
+  }
+
+  /**
+   * Internal method for `extractDataFromGlb`, covering glTF 1.0.
+   *
+   * @param glbBuffer - The buffer containing the GLB
+   * @returns The JSON- and binary data buffers
+   * @throws TileFormatError If the input does not contain valid GLB data.
+   */
+  private static extractDataFromGlb1(glbBuffer: Buffer): {
+    jsonData: Buffer;
+    binData: Buffer;
+  } {
+    if (glbBuffer.length < 20) {
+      throw new TileFormatError(
+        `Expected at least 20 bytes, but only got ${glbBuffer.length}`
+      );
+    }
+    const contentLength = glbBuffer.readUint32LE(12);
+    const contentFormat = glbBuffer.readUint32LE(16);
+    if (contentFormat !== 0) {
+      throw new TileFormatError(
+        `Expected content format to be 0, but found ${contentFormat}`
+      );
+    }
+    const contentStart = 20;
+    const contentEnd = contentStart + contentLength;
+    if (glbBuffer.length < contentEnd) {
+      throw new TileFormatError(
+        `Expected at least ${contentEnd} bytes, but only got ${glbBuffer.length}`
+      );
+    }
+    const contentData = glbBuffer.subarray(contentStart, contentEnd);
+
+    const bodyStart = 20 + contentLength;
+    const bodyEnd = glbBuffer.length;
+    const bodyData = glbBuffer.subarray(bodyStart, bodyEnd);
+    return {
+      jsonData: contentData,
+      binData: bodyData,
+    };
+  }
+
+  /**
+   * Internal method for `extractDataFromGlb`, covering glTF 2.0.
+   *
+   * @param glbBuffer - The buffer containing the GLB
+   * @returns The JSON- and binary data buffers
+   * @throws TileFormatError If the input does not contain valid GLB data.
+   */
+  private static extractDataFromGlb2(glbBuffer: Buffer) {
+    if (glbBuffer.length < 20) {
+      throw new TileFormatError(
+        `Expected at least 20 bytes, but only got ${glbBuffer.length}`
+      );
+    }
+
+    // Extract the JSON chunk data
+    const jsonChunkLength = glbBuffer.readUint32LE(12);
+    const jsonChunkType = glbBuffer.readUint32LE(16);
+    const expectedJsonChunkType = 0x4e4f534a; // ASCII string for "JSON"
+    if (jsonChunkType !== expectedJsonChunkType) {
+      throw new TileFormatError(
+        `Expected chunk type to be ${expectedJsonChunkType}, but found ${jsonChunkType}`
+      );
+    }
+    const jsonChunkStart = 20;
+    const jsonChunkEnd = jsonChunkStart + jsonChunkLength;
+    if (glbBuffer.length < jsonChunkEnd) {
+      throw new TileFormatError(
+        `Expected at least ${jsonChunkEnd} bytes, but only got ${glbBuffer.length}`
+      );
+    }
+    const jsonChunkData = glbBuffer.subarray(jsonChunkStart, jsonChunkEnd);
+
+    // Extract the BIN chunk data
+    const binChunkHeaderStart = jsonChunkEnd;
+    const binChunkLength = glbBuffer.readUint32LE(binChunkHeaderStart);
+    const binChunkType = glbBuffer.readUint32LE(binChunkHeaderStart + 4);
+    const expectedBinChunkType = 0x004e4942; // ASCII string for "BIN"
+    if (binChunkType !== expectedBinChunkType) {
+      throw new TileFormatError(
+        `Expected chunk type to be ${expectedBinChunkType}, but found ${binChunkType}`
+      );
+    }
+    const binChunkStart = binChunkHeaderStart + 8;
+    const binChunkEnd = binChunkStart + binChunkLength;
+    if (glbBuffer.length < binChunkEnd) {
+      throw new TileFormatError(
+        `Expected at least ${binChunkEnd} bytes, but only got ${glbBuffer.length}`
+      );
+    }
+
+    const binChunkData = glbBuffer.subarray(binChunkStart, binChunkEnd);
+
+    return {
+      jsonData: jsonChunkData,
+      binData: binChunkData,
+    };
+  }
+
+  /**
    * Extract the JSON part from the given GLB buffer and return it
    * as a buffer.
    *
@@ -64,72 +207,8 @@ export class GltfUtilities {
    * @throws TileFormatError If the input does not contain valid GLB data.
    */
   static extractJsonFromGlb(glbBuffer: Buffer): Buffer {
-    const magic = Buffers.getMagicString(glbBuffer);
-    if (magic !== "glTF") {
-      throw new TileFormatError(
-        `Expected magic header to be 'gltf', but found ${magic}`
-      );
-    }
-    if (glbBuffer.length < 12) {
-      throw new TileFormatError(
-        `Expected at least 12 bytes, but only got ${glbBuffer.length}`
-      );
-    }
-    const version = glbBuffer.readUInt32LE(4);
-    const length = glbBuffer.readUInt32LE(8);
-    if (length > glbBuffer.length) {
-      throw new TileFormatError(
-        `Header indicates ${length} bytes, but input has ${glbBuffer.length} bytes`
-      );
-    }
-    if (version === 1) {
-      if (glbBuffer.length < 20) {
-        throw new TileFormatError(
-          `Expected at least 20 bytes, but only got ${glbBuffer.length}`
-        );
-      }
-      const contentLength = glbBuffer.readUint32LE(12);
-      const contentFormat = glbBuffer.readUint32LE(16);
-      if (contentFormat !== 0) {
-        throw new TileFormatError(
-          `Expected content format to be 0, but found ${contentFormat}`
-        );
-      }
-      const contentStart = 20;
-      const contentEnd = contentStart + contentLength;
-      if (glbBuffer.length < contentEnd) {
-        throw new TileFormatError(
-          `Expected at least ${contentEnd} bytes, but only got ${glbBuffer.length}`
-        );
-      }
-      const contentData = glbBuffer.subarray(contentStart, contentEnd);
-      return contentData;
-    } else if (version === 2) {
-      if (glbBuffer.length < 20) {
-        throw new TileFormatError(
-          `Expected at least 20 bytes, but only got ${glbBuffer.length}`
-        );
-      }
-      const chunkLength = glbBuffer.readUint32LE(12);
-      const chunkType = glbBuffer.readUint32LE(16);
-      const jsonChunkType = 0x4e4f534a; // ASCII string for "JSON"
-      if (chunkType !== jsonChunkType) {
-        throw new TileFormatError(
-          `Expected chunk type to be ${jsonChunkType}, but found ${chunkType}`
-        );
-      }
-      const chunkStart = 20;
-      const chunkEnd = chunkStart + chunkLength;
-      if (glbBuffer.length < chunkEnd) {
-        throw new TileFormatError(
-          `Expected at least ${chunkEnd} bytes, but only got ${glbBuffer.length}`
-        );
-      }
-      const chunkData = glbBuffer.subarray(chunkStart, chunkEnd);
-      return chunkData;
-    } else {
-      throw new TileFormatError(`Expected version 1 or 2, but got ${version}`);
-    }
+    const data = GltfUtilities.extractDataFromGlb(glbBuffer);
+    return data.jsonData;
   }
 
   /**

--- a/src/gltfExtensions/StructuralMetadataPropertyTables.ts
+++ b/src/gltfExtensions/StructuralMetadataPropertyTables.ts
@@ -67,7 +67,8 @@ export class StructuralMetadataPropertyTables {
 
     // Create all PropertyTablePropery objects, and put
     // them into the PropertyTable
-    const metadataClass = binaryPropertyTable.metadataClass;
+    const binaryMetadata = binaryPropertyTable.binaryMetadata;
+    const metadataClass = binaryMetadata.metadataClass;
     const classProperties = metadataClass.properties || {};
     const propertyNames = Object.keys(classProperties);
     for (const propertyName of propertyNames) {
@@ -124,7 +125,8 @@ export class StructuralMetadataPropertyTables {
     }
 
     // Obtain the required buffers from the binary data:
-    const binaryBufferData = binaryPropertyTable.binaryBufferData;
+    const binaryMetadata = binaryPropertyTable.binaryMetadata;
+    const binaryBufferData = binaryMetadata.binaryBufferData;
     const bufferViewsData = binaryBufferData.bufferViewsData;
 
     // Obtain the `values` buffer view data

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export * from "./metadata/PropertyModel";
 export * from "./metadata/PropertyTableModel";
 
 export * from "./metadata/binary/BinaryPropertyTable";
+export * from "./metadata/binary/BinaryMetadata";
 export * from "./metadata/binary/BinaryPropertyTables";
 export * from "./metadata/binary/BinaryPropertyTableModel";
 export * from "./metadata/binary/BinaryEnumInfo";

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,3 +117,8 @@ export * from "./traversal/SubtreeModels";
 export * from "./traversal/TilesetTraverser";
 export * from "./traversal/TraversedTile";
 export * from "./traversal/TraversalCallback";
+
+// For glTF extension validation experiments
+
+export * from "./contentProcessing/GltfUtilities";
+export * from "./contentProcessing/GltfTransform";

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export * from "./metadata/binary/BinaryPropertyTable";
 export * from "./metadata/binary/BinaryMetadata";
 export * from "./metadata/binary/BinaryPropertyTables";
 export * from "./metadata/binary/BinaryPropertyTableModel";
+export * from "./metadata/binary/BinaryPropertyModels";
 export * from "./metadata/binary/BinaryEnumInfo";
 export * from "./metadata/binary/NumericBuffers";
 

--- a/src/metadata/DefaultPropertyTableModel.ts
+++ b/src/metadata/DefaultPropertyTableModel.ts
@@ -9,7 +9,11 @@ import { ClassProperty } from "../structure/Metadata/ClassProperty";
 
 /**
  * Implementation of a `PropertyTableModel` that is backed by
- * `PropertyModel` instances
+ * `PropertyModel` instances.
+ *
+ * This implementation is only used internally, to represent
+ * data from batch tables, and does not support property
+ * semantics or enum types.
  *
  * @internal
  */
@@ -81,10 +85,12 @@ export class DefaultPropertyTableModel implements PropertyTableModel {
       throw new MetadataError(message);
     }
     const semanticToPropertyId = {};
+    const enumValueValueNames = {};
     const metadataEntityModel = new TableMetadataEntityModel(
       this,
       index,
-      semanticToPropertyId
+      semanticToPropertyId,
+      enumValueValueNames
     );
     return metadataEntityModel;
   }

--- a/src/metadata/MetadataEntityModels.ts
+++ b/src/metadata/MetadataEntityModels.ts
@@ -7,6 +7,7 @@ import { MetadataError } from "./MetadataError";
 import { Schema } from "../structure/Metadata/Schema";
 import { MetadataEntity } from "../structure/MetadataEntity";
 import { MetadataClass } from "../structure/Metadata/MetadataClass";
+import { MetadataEnum } from "../structure/Metadata/MetadataEnum";
 
 /**
  * Methods related to `MetadataEntityModel` instances.
@@ -49,7 +50,11 @@ export class MetadataEntityModels {
       throw new MetadataError(`Schema does not contain class ${entity.class}`);
     }
     const entityProperties = entity.properties ?? {};
-    return this.createFromClass(metadataClass, entityProperties);
+    return this.createFromClass(
+      metadataClass,
+      schema.enums || {},
+      entityProperties
+    );
   }
 
   /**
@@ -59,11 +64,14 @@ export class MetadataEntityModels {
    * See the `create` method for details.
    *
    * @param metadataClass - The `MetadataClass`
+   * @param metadataEnums - The enum definitions from the schema, for
+   * the case that the class contains enum properties
    * @param entityProperties - The properties of the `MetadataEntity`
    * @returns The `MetadataEntityModel`
    */
   static createFromClass(
     metadataClass: MetadataClass,
+    metadataEnums: { [key: string]: MetadataEnum },
     entityProperties: { [key: string]: any }
   ) {
     // TODO This should not be done for each entity. The lookup

--- a/src/metadata/MetadataUtilities.ts
+++ b/src/metadata/MetadataUtilities.ts
@@ -4,6 +4,7 @@ import { BinaryEnumInfo } from "./binary/BinaryEnumInfo";
 
 import { Schema } from "../structure/Metadata/Schema";
 import { ClassProperty } from "../structure/Metadata/ClassProperty";
+import { MetadataEnum } from "../structure/Metadata/MetadataEnum";
 
 /**
  * Internal utilities related to metadata
@@ -23,6 +24,7 @@ export class MetadataUtilities {
     const binaryEnumInfo: BinaryEnumInfo = {
       enumValueTypes: MetadataUtilities.computeEnumValueTypes(schema),
       enumValueNameValues: MetadataUtilities.computeEnumValueNameValues(schema),
+      enumValueValueNames: MetadataUtilities.computeEnumValueValueNames(schema),
     };
     return binaryEnumInfo;
   }
@@ -51,6 +53,39 @@ export class MetadataUtilities {
   }
 
   /**
+   * Computes the value type of the enum that is represented with
+   * the given class property.
+   *
+   * This assumes that the given schema and class property are
+   * structurally valid: If the class property is not an ENUM
+   * property, or the schema does not define enums, then
+   * `undefined` is returned.
+   *
+   * Otherwise, the `valueType´ of the respective enum is returned
+   * (defaulting to `UINT16` if it did not define one).
+   *
+   * @param schema - The metadata `Schema`
+   * @param classProperty - The `ClassProperty`
+   * @returns The enum value type, or `undefined`.
+   */
+  static computeEnumValueType(
+    schema: Schema,
+    classProperty: ClassProperty
+  ): string | undefined {
+    const enumType = classProperty.enumType;
+    if (enumType === undefined) {
+      return undefined;
+    }
+    const enums = schema.enums;
+    if (enums === undefined) {
+      return undefined;
+    }
+    const metadataEnum = enums[enumType];
+    const valueType = metadataEnum.valueType ?? "UINT16";
+    return valueType;
+  }
+
+  /**
    * Computes a mapping from enum type names to the dictionaries
    * that map the enum values names to the enum value values.
    *
@@ -71,19 +106,88 @@ export class MetadataUtilities {
     if (enums) {
       for (const enumName of Object.keys(enums)) {
         const metadataEnum = enums[enumName];
-        const nameValues: {
-          [key: string]: number;
-        } = {};
-        for (let i = 0; i < metadataEnum.values.length; i++) {
-          const enumValue = metadataEnum.values[i];
-          const value = enumValue.value;
-          const name = enumValue.name;
-          nameValues[name] = value;
-        }
+        const nameValues =
+          MetadataUtilities.computeMetadataEnumValueNameValues(metadataEnum);
         enumValueNameValues[enumName] = nameValues;
       }
     }
     return enumValueNameValues;
+  }
+  /**
+   * Computes a mapping from enum values names to the enum value values
+   * for the given metadata enum.
+   *
+   * @param metadataEnum - The metadata enum
+   * @returns The mapping from enum value names to enum value values
+   */
+  static computeMetadataEnumValueNameValues(metadataEnum: MetadataEnum): {
+    [key: string]: number;
+  } {
+    const nameValues: {
+      [key: string]: number;
+    } = {};
+    for (let i = 0; i < metadataEnum.values.length; i++) {
+      const enumValue = metadataEnum.values[i];
+      const value = enumValue.value;
+      const name = enumValue.name;
+      nameValues[name] = value;
+    }
+    return nameValues;
+  }
+
+  /**
+   * Computes a mapping from enum type names to the dictionaries
+   * that map the enum value values to the enum value names.
+   *
+   * @param schema - The metadata `Schema`
+   * @returns The mapping from enum type names to dictionaries
+   */
+  private static computeEnumValueValueNames(schema: Schema): {
+    [key: string]: {
+      [key: number]: string;
+    };
+  } {
+    const enumValueValueNames: {
+      [key: string]: {
+        [key: number]: string;
+      };
+    } = {};
+    const enums = schema.enums;
+    if (enums) {
+      for (const enumName of Object.keys(enums)) {
+        const metadataEnum = enums[enumName];
+        const valueNames =
+          MetadataUtilities.computeMetadataEnumValueValueNames(metadataEnum);
+        enumValueValueNames[enumName] = valueNames;
+      }
+    }
+    return enumValueValueNames;
+  }
+
+  /**
+   * Computes a mapping from enum value values to enum value names
+   * for the given metadata enum.
+   *
+   * The name and comment look strange, but this is indeed the mapping from
+   * `metadataEnum.values[i].value` to `metadataEnum.values[i].name` for
+   * the given metadata enum.
+   *
+   * @param metadataEnum - The metadata enum
+   * @returns The mapping from enum value values to enum value names.
+   */
+  static computeMetadataEnumValueValueNames(metadataEnum: MetadataEnum): {
+    [key: number]: string;
+  } {
+    const valueNames: {
+      [key: number]: string;
+    } = {};
+    for (let i = 0; i < metadataEnum.values.length; i++) {
+      const enumValue = metadataEnum.values[i];
+      const value = enumValue.value;
+      const name = enumValue.name;
+      valueNames[value] = name;
+    }
+    return valueNames;
   }
 
   /**

--- a/src/metadata/MetadataValues.ts
+++ b/src/metadata/MetadataValues.ts
@@ -109,12 +109,9 @@ export class MetadataValues {
    * of the enum value into the string representation.
    *
    * @param classProperty - The `ClassProperty`
-   * @param offsetOverride -: An optional override for the
-   * `offset` of the `ClassProperty`. If this is defined, then
-   * it will be used instead of the one from the class property.
-   * @param scaleOverride -: An optional override for the
-   * `scale` of the `ClassProperty`. If this is defined, then
-   * it will be used instead of the one from the class property.
+   * @param valueValueNames - The mapping from enum value values
+   * to enum value names for the enum type of the given class
+   * property.
    * @param value - The value
    * @returns The processed value
    */

--- a/src/metadata/MetadataValues.ts
+++ b/src/metadata/MetadataValues.ts
@@ -94,4 +94,51 @@ export class MetadataValues {
     }
     return value;
   }
+
+  /**
+   * Processes the given "raw" value that was obtained for a metadata
+   * ENUM property in a numeric form (e.g. from a binary property
+   * table), and returns the processed value according to the type
+   * definition that is given by the given class property.
+   *
+   * If the type defines a `noData` value, and the given value
+   * is the `noData` value, then the `default` value of the type
+   * is returned.
+   *
+   * Otherwise, this will translate the numeric representation
+   * of the enum value into the string representation.
+   *
+   * @param classProperty - The `ClassProperty`
+   * @param offsetOverride -: An optional override for the
+   * `offset` of the `ClassProperty`. If this is defined, then
+   * it will be used instead of the one from the class property.
+   * @param scaleOverride -: An optional override for the
+   * `scale` of the `ClassProperty`. If this is defined, then
+   * it will be used instead of the one from the class property.
+   * @param value - The value
+   * @returns The processed value
+   */
+  static processNumericEnumValue(
+    classProperty: ClassProperty,
+    valueValueNames: { [key: number]: string },
+    value: number | number[]
+  ): any {
+    let stringValue;
+    if (Array.isArray(value)) {
+      stringValue = value.map((e: number) => valueValueNames[e]);
+    } else {
+      stringValue = valueValueNames[value];
+    }
+    const noData = classProperty.noData;
+    const defaultValue = classProperty.default;
+    if (defined(noData)) {
+      if (ArrayValues.deepEquals(stringValue, noData)) {
+        return ArrayValues.deepClone(defaultValue);
+      }
+    }
+    if (!defined(stringValue)) {
+      return ArrayValues.deepClone(defaultValue);
+    }
+    return stringValue;
+  }
 }

--- a/src/metadata/binary/BinaryEnumInfo.ts
+++ b/src/metadata/binary/BinaryEnumInfo.ts
@@ -21,4 +21,11 @@ export interface BinaryEnumInfo {
    * to the `enum.values[i].value`
    */
   enumValueNameValues: { [key: string]: { [key: string]: number } };
+
+  /**
+   * A mapping from enum type names (enum IDs) to
+   * dictionaries that map the `enum.values[i].value`
+   * to the `enum.values[i].name`
+   */
+  enumValueValueNames: { [key: string]: { [key: number]: string } };
 }

--- a/src/metadata/binary/BinaryMetadata.ts
+++ b/src/metadata/binary/BinaryMetadata.ts
@@ -1,0 +1,45 @@
+import { BinaryBufferData } from "../../binary/BinaryBufferData";
+import { BinaryBufferStructure } from "../../binary/BinaryBufferStructure";
+
+import { BinaryEnumInfo } from "./BinaryEnumInfo";
+
+import { MetadataClass } from "../../structure/Metadata/MetadataClass";
+
+/**
+ * A basic structure summarizing the (raw) elements of binary metadata.
+ *
+ * It contains information about the structure of the data (given
+ * as the `MetadataClass`), as well as the binary data, stored in
+ * `Buffer` objects.
+ *
+ * @internal
+ */
+export interface BinaryMetadata {
+  /**
+   * The `MetadataClass` that describes the structure of this metadata
+   */
+  metadataClass: MetadataClass;
+
+  /**
+   * Information about the binary representation of `MetadataEnum`
+   * values
+   */
+  binaryEnumInfo: BinaryEnumInfo;
+
+  /**
+   * The binary buffer structure, containing the `BufferObject` and
+   * `BufferView` objects.
+   *
+   * The metadata property objects contain indices (e.g. the
+   * `propertyTableProperty.values` index) that refer to this
+   * structure.
+   */
+  binaryBufferStructure: BinaryBufferStructure;
+
+  /**
+   * The binary buffer data. These are the actual buffers with
+   * the binary data that correspond to the elements of the
+   * `BinaryBufferStructure`.
+   */
+  binaryBufferData: BinaryBufferData;
+}

--- a/src/metadata/binary/BinaryPropertyModels.ts
+++ b/src/metadata/binary/BinaryPropertyModels.ts
@@ -18,18 +18,19 @@ import { NumericBuffers } from "./NumericBuffers";
  */
 export class BinaryPropertyModels {
   /**
-   * Creates a `PropertyModel` for the specified property in
-   * the given `BinaryPropertyTable`.
+   * Creates a `PropertyModel` for the specified property in the
+   * given property table, based on the given binary metadata.
    *
    * This assumes that the input is structurally valid.
    *
    * This will determine the type of the property and access its
    * associated data (i.e. the required buffer views data) from
-   * the given `BinaryPropertyTable`. For each type of property,
+   * the given `BinaryMetadata`. For each type of property,
    * this will return a matching implementation of the
    * `PropertyModel` interface.
    *
-   * @param binaryPropertyTable - The `BinaryPropertyTable`
+   * @param propertyTable - The `PropertyTable`
+   * @param binaryMetadata - The `BinaryMetadata`
    * @param propertyId - The property ID
    * @returns The `PropertyModel`
    * @throws MetadataError If the input data is not structurally
@@ -51,7 +52,8 @@ export class BinaryPropertyModels {
     // check could be avoided.
 
     // Obtain the `ClassProperty`
-    const metadataClass = binaryPropertyTable.metadataClass;
+    const binaryMetadata = binaryPropertyTable.binaryMetadata;
+    const metadataClass = binaryMetadata.metadataClass;
     const classProperties = metadataClass.properties;
     if (!classProperties) {
       throw new MetadataError(`The class does not define any properties`);
@@ -79,7 +81,7 @@ export class BinaryPropertyModels {
     }
 
     // Obtain the required buffers from the binary data:
-    const binaryBufferData = binaryPropertyTable.binaryBufferData;
+    const binaryBufferData = binaryMetadata.binaryBufferData;
     const bufferViewsData = binaryBufferData.bufferViewsData;
 
     // Obtain the `values` buffer view data
@@ -107,7 +109,7 @@ export class BinaryPropertyModels {
     const enumType = classProperty.enumType;
     let enumValueType = undefined;
     if (enumType !== undefined) {
-      const binaryEnumInfo = binaryPropertyTable.binaryEnumInfo;
+      const binaryEnumInfo = binaryMetadata.binaryEnumInfo;
       const enumValueTypes = binaryEnumInfo.enumValueTypes;
       enumValueType = enumValueTypes[enumType] ?? "UINT16";
     }

--- a/src/metadata/binary/BinaryPropertyTable.ts
+++ b/src/metadata/binary/BinaryPropertyTable.ts
@@ -1,53 +1,20 @@
-import { BinaryBufferData } from "../../binary/BinaryBufferData";
-import { BinaryBufferStructure } from "../../binary/BinaryBufferStructure";
-
-import { BinaryEnumInfo } from "./BinaryEnumInfo";
-
-import { MetadataClass } from "../../structure/Metadata/MetadataClass";
 import { PropertyTable } from "../../structure/PropertyTable";
+import { BinaryMetadata } from "./BinaryMetadata";
 
 /**
  * A basic structure summarizing the (raw) elements of a binary
  * property table.
  *
- * It contains information about the structure of the table itself,
- * consisting of the `PropertyTable` and the `MetadataClass`, as
- * well as the binary data, stored in `Buffer` objects.
- *
- * Instances of this interface serve as the input for the
- * construction of a `PropertyTableModel`.
- *
  * @internal
  */
 export interface BinaryPropertyTable {
   /**
-   * The actual `PropertyTable` object
+   * The actual property table
    */
   propertyTable: PropertyTable;
 
   /**
-   * The `MetadataClass` that corresponds to the `propertyTable.class`
+   * The binary metadata that is backing the property table
    */
-  metadataClass: MetadataClass;
-
-  /**
-   * Information about the binary representation of `MetadataEnum`
-   * values
-   */
-  binaryEnumInfo: BinaryEnumInfo;
-
-  /**
-   * The binary buffer structure, containing the `BufferObject` and
-   * `BufferView` objects. The `PropertyTableProperty` objects
-   * from the `PropertyTable` contain indices (e.g. the `values`
-   * index) that refer to this structure.
-   */
-  binaryBufferStructure: BinaryBufferStructure;
-
-  /**
-   * The binary buffer data. These are the actual buffers with
-   * the binary data that correspond to the elements of the
-   * `BinaryBufferStructure`.
-   */
-  binaryBufferData: BinaryBufferData;
+  binaryMetadata: BinaryMetadata;
 }

--- a/src/metadata/binary/BinaryPropertyTableBuilder.ts
+++ b/src/metadata/binary/BinaryPropertyTableBuilder.ts
@@ -9,11 +9,12 @@ import { PropertyTableProperty } from "../../structure/PropertyTableProperty";
 import { MetadataError } from "../MetadataError";
 
 import { MetadataUtilities } from "../MetadataUtilities";
+import { BinaryMetadata } from "./BinaryMetadata";
 import { BinaryPropertyTable } from "./BinaryPropertyTable";
 import { BinaryPropertyTables } from "./BinaryPropertyTables";
 
 /**
- * A class for building `BinaryPropertyModel` instances
+ * A class for building `BinaryPropertyTable` objects
  * from property values that are given as arrays.
  *
  * @internal
@@ -191,10 +192,10 @@ export class BinaryPropertyTableBuilder {
   }
 
   /**
-   * Build the `BinaryPropertyTable` from the data of all properties
+   * Build the property table from the data of all properties
    * that have been added.
    *
-   * @returns The `BinaryPropertyTable`
+   * @returns The property table
    * @throws MetadataError If no property values have been given
    * for any of the properties of the class that the table is
    * built for
@@ -233,12 +234,15 @@ export class BinaryPropertyTableBuilder {
     const binaryEnumInfo = MetadataUtilities.computeBinaryEnumInfo(this.schema);
 
     const metadataClass = this.getClass();
-    const binaryPropertyTable: BinaryPropertyTable = {
+    const binaryMetadata: BinaryMetadata = {
       metadataClass: metadataClass,
-      propertyTable: propertyTable,
       binaryEnumInfo: binaryEnumInfo,
       binaryBufferStructure: binaryBufferStructure,
       binaryBufferData: binaryBufferData,
+    };
+    const binaryPropertyTable: BinaryPropertyTable = {
+      propertyTable: propertyTable,
+      binaryMetadata: binaryMetadata,
     };
     return binaryPropertyTable;
   }

--- a/src/metadata/binary/BinaryPropertyTableModel.ts
+++ b/src/metadata/binary/BinaryPropertyTableModel.ts
@@ -71,10 +71,14 @@ export class BinaryPropertyTableModel implements PropertyTableModel {
       throw new MetadataError(message);
     }
     const semanticToPropertyId = this.semanticToPropertyId;
+    const binaryMetadata = binaryPropertyTable.binaryMetadata;
+    const binaryEnumInfo = binaryMetadata.binaryEnumInfo;
+    const enumValueValueNames = binaryEnumInfo.enumValueValueNames;
     const metadataEntityModel = new TableMetadataEntityModel(
       this,
       index,
-      semanticToPropertyId
+      semanticToPropertyId,
+      enumValueValueNames
     );
     return metadataEntityModel;
   }

--- a/src/metadata/binary/BinaryPropertyTableModel.ts
+++ b/src/metadata/binary/BinaryPropertyTableModel.ts
@@ -1,5 +1,4 @@
 import { BinaryPropertyModels } from "./BinaryPropertyModels";
-import { BinaryPropertyTable } from "./BinaryPropertyTable";
 import { TableMetadataEntityModel } from "../TableMetadataEntityModel";
 
 import { MetadataEntityModel } from "../MetadataEntityModel";
@@ -10,6 +9,7 @@ import { PropertyTableModel } from "../PropertyTableModel";
 
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
 import { PropertyTableProperty } from "../../structure/PropertyTableProperty";
+import { BinaryPropertyTable } from "./BinaryPropertyTable";
 
 /**
  * Implementation of the `PropertyTableModel` interface that is backed
@@ -19,8 +19,8 @@ import { PropertyTableProperty } from "../../structure/PropertyTableProperty";
  */
 export class BinaryPropertyTableModel implements PropertyTableModel {
   /**
-   * The structure containing the raw data of the binary
-   * property table
+   * The structure containing the raw PropertyTable JSON object
+   * and binary data of the property table
    */
   private readonly binaryPropertyTable: BinaryPropertyTable;
 
@@ -43,26 +43,28 @@ export class BinaryPropertyTableModel implements PropertyTableModel {
 
     // Initialize the `PropertyModel` instances for
     // the property table properties
-    const propertyTable = this.binaryPropertyTable.propertyTable;
+    const propertyTable = binaryPropertyTable.propertyTable;
     const propertyTableProperties = propertyTable.properties;
     if (propertyTableProperties) {
       for (const propertyId of Object.keys(propertyTableProperties)) {
         const propertyModel = BinaryPropertyModels.createPropertyModel(
-          this.binaryPropertyTable,
+          binaryPropertyTable,
           propertyId
         );
         this.propertyIdToModel[propertyId] = propertyModel;
       }
     }
 
-    const metadataClass = binaryPropertyTable.metadataClass;
+    const binaryMetadata = binaryPropertyTable.binaryMetadata;
+    const metadataClass = binaryMetadata.metadataClass;
     this.semanticToPropertyId =
       MetadataEntityModels.computeSemanticToPropertyIdMapping(metadataClass);
   }
 
   /** {@inheritDoc PropertyTableModel.getMetadataEntityModel} */
   getMetadataEntityModel(index: number): MetadataEntityModel {
-    const propertyTable = this.binaryPropertyTable.propertyTable;
+    const binaryPropertyTable = this.binaryPropertyTable;
+    const propertyTable = binaryPropertyTable.propertyTable;
     const count = propertyTable.count;
     if (index < 0 || index >= count) {
       const message = `The index must be in [0,${count}), but is ${index}`;
@@ -85,7 +87,8 @@ export class BinaryPropertyTableModel implements PropertyTableModel {
   /** {@inheritDoc PropertyTableModel.getClassProperty} */
   getClassProperty(propertyId: string): ClassProperty | undefined {
     const binaryPropertyTable = this.binaryPropertyTable;
-    const metadataClass = binaryPropertyTable.metadataClass;
+    const binaryMetadata = binaryPropertyTable.binaryMetadata;
+    const metadataClass = binaryMetadata.metadataClass;
     const classProperties = metadataClass.properties;
     if (!classProperties) {
       return undefined;
@@ -111,6 +114,8 @@ export class BinaryPropertyTableModel implements PropertyTableModel {
   }
 
   getCount(): number {
-    return this.binaryPropertyTable.propertyTable.count;
+    const binaryPropertyTable = this.binaryPropertyTable;
+    const propertyTable = binaryPropertyTable.propertyTable;
+    return propertyTable.count;
   }
 }

--- a/src/metadata/binary/BinaryPropertyTables.ts
+++ b/src/metadata/binary/BinaryPropertyTables.ts
@@ -16,7 +16,6 @@ import { PropertyTableProperty } from "../../structure/PropertyTableProperty";
 import { Schema } from "../../structure/Metadata/Schema";
 import { MetadataClass } from "../../structure/Metadata/MetadataClass";
 import { ClassProperty } from "../../structure/Metadata/ClassProperty";
-import { EnumValue } from "../../structure/Metadata/EnumValue";
 import { MetadataEnum } from "../../structure/Metadata/MetadataEnum";
 
 /**
@@ -507,12 +506,13 @@ export class BinaryPropertyTables {
       if (!metadataEnum) {
         throw new MetadataError(`The schema does not define enum ${enumType}`);
       }
-      const valueNames = metadataEnum.values.map((v: EnumValue) => v.name);
+      const nameValues =
+        MetadataUtilities.computeMetadataEnumValueNameValues(metadataEnum);
       componentType = defaultValue(metadataEnum.valueType, "UINT16");
       for (let i = 0; i < length; ++i) {
         const valueName = flattenedValues[i];
-        const index = valueNames.indexOf(valueName);
-        flattenedValues[i] = index;
+        const valueValue = nameValues[valueName];
+        flattenedValues[i] = valueValue;
       }
     }
 

--- a/src/metadata/binary/BinaryPropertyTables.ts
+++ b/src/metadata/binary/BinaryPropertyTables.ts
@@ -2,6 +2,7 @@ import { defined } from "../../base/defined";
 import { defaultValue } from "../../base/defaultValue";
 
 import { BinaryPropertyTable } from "./BinaryPropertyTable";
+import { BinaryMetadata } from "./BinaryMetadata";
 
 import { BinaryBufferData } from "../../binary/BinaryBufferData";
 import { BinaryBuffers } from "../../binary/BinaryBuffers";
@@ -267,7 +268,7 @@ export class BinaryPropertyTables {
     arrayOffsetType: string | undefined,
     stringOffsetType: string | undefined,
     metadataEnum: MetadataEnum | undefined
-  ): BinaryPropertyTable {
+  ): { propertyTable: PropertyTable; binaryMetadata: BinaryMetadata } {
     const schema = BinaryPropertyTables.createSchemaFromClassProperty(
       propertyName,
       classProperty,
@@ -367,12 +368,15 @@ export class BinaryPropertyTables {
 
     const binaryEnumInfo = MetadataUtilities.computeBinaryEnumInfo(schema);
 
-    const binaryPropertyTable: BinaryPropertyTable = {
+    const binaryMetadata: BinaryMetadata = {
       metadataClass: metadataClass,
-      propertyTable: propertyTable,
       binaryEnumInfo: binaryEnumInfo,
       binaryBufferStructure: binaryBufferStructure,
       binaryBufferData: binaryBufferData,
+    };
+    const binaryPropertyTable: BinaryPropertyTable = {
+      propertyTable: propertyTable,
+      binaryMetadata: binaryMetadata,
     };
     return binaryPropertyTable;
   }

--- a/src/metadata/binary/BinaryPropertyTables.ts
+++ b/src/metadata/binary/BinaryPropertyTables.ts
@@ -267,7 +267,7 @@ export class BinaryPropertyTables {
     arrayOffsetType: string | undefined,
     stringOffsetType: string | undefined,
     metadataEnum: MetadataEnum | undefined
-  ): { propertyTable: PropertyTable; binaryMetadata: BinaryMetadata } {
+  ): BinaryPropertyTable {
     const schema = BinaryPropertyTables.createSchemaFromClassProperty(
       propertyName,
       classProperty,

--- a/src/metadata/binary/BooleanArrayPropertyModel.ts
+++ b/src/metadata/binary/BooleanArrayPropertyModel.ts
@@ -1,7 +1,7 @@
 import { PropertyModel } from "../PropertyModel";
 
 import { BinaryPropertyModels } from "./BinaryPropertyModels";
-import { BooleanPropertyModel } from "./BooleanPropertyModel";
+import { NumericBuffers } from "./NumericBuffers";
 
 /**
  * Implementation of a `PropertyModel` for boolean arrays
@@ -45,10 +45,7 @@ export class BooleanArrayPropertyModel implements PropertyModel {
     const result = Array<boolean>(arrayLength);
     for (let i = 0; i < arrayLength; i++) {
       const n = arrayOffset + i;
-      const element = BooleanPropertyModel.getBooleanFromBuffer(
-        valuesBuffer,
-        n
-      );
+      const element = NumericBuffers.getBooleanFromBuffer(valuesBuffer, n);
       result[i] = element;
     }
     return result;

--- a/src/metadata/binary/BooleanPropertyModel.ts
+++ b/src/metadata/binary/BooleanPropertyModel.ts
@@ -17,21 +17,7 @@ export class BooleanPropertyModel implements PropertyModel {
   /** {@inheritDoc PropertyModel.getPropertyValue} */
   getPropertyValue(index: number): boolean {
     const valuesBuffer = this.valuesBuffer;
-    const result = BooleanPropertyModel.getBooleanFromBuffer(
-      valuesBuffer,
-      index
-    );
-    return result;
-  }
-
-  static getBooleanFromBuffer(buffer: Buffer, index: number): boolean {
-    const byteIndex = Math.floor(index / 8);
-    const bitIndex = index % 8;
-    const byte = Number(
-      NumericBuffers.getNumericFromBuffer(buffer, byteIndex, "UINT8")
-    );
-    const bit = 1 << bitIndex;
-    const result = (byte & bit) !== 0;
+    const result = NumericBuffers.getBooleanFromBuffer(valuesBuffer, index);
     return result;
   }
 }

--- a/src/metadata/binary/NumericBuffers.ts
+++ b/src/metadata/binary/NumericBuffers.ts
@@ -148,4 +148,21 @@ export class NumericBuffers {
     const array = [...typedArray];
     return array;
   }
+
+  /**
+   * Returns a boolean value from the specified buffer, at the specified
+   * bit index
+   *
+   * @param buffer - The buffer
+   * @param index - The bit index
+   * @returns The boolean value
+   */
+  static getBooleanFromBuffer(buffer: Buffer, index: number): boolean {
+    const byteIndex = Math.floor(index / 8);
+    const bitIndex = index % 8;
+    const byte = buffer.readUint8(byteIndex);
+    const bit = 1 << bitIndex;
+    const result = (byte & bit) !== 0;
+    return result;
+  }
 }

--- a/src/traversal/SubtreeMetadataModels.ts
+++ b/src/traversal/SubtreeMetadataModels.ts
@@ -14,6 +14,7 @@ import { SubtreeInfo } from "../implicitTiling/SubtreeInfo";
 import { AvailabilityInfo } from "../implicitTiling/AvailabilityInfo";
 
 import { SubtreeMetadataModel } from "./SubtreeMetadataModel";
+import { BinaryMetadata } from "../metadata/binary/BinaryMetadata";
 
 /**
  * Methods to create `SubtreeMetadataModel` instances.
@@ -77,12 +78,15 @@ export class SubtreeMetadataModels {
         // Create the `BinaryPropertyTable` for each property table,
         // which contains everything that is required for creating
         // the binary PropertyTableModel
-        const binaryPropertyTable: BinaryPropertyTable = {
-          propertyTable: propertyTable,
+        const binaryMetadata: BinaryMetadata = {
           metadataClass: metadataClass,
           binaryEnumInfo: binaryEnumInfo,
           binaryBufferStructure: binaryBufferStructure,
           binaryBufferData: binaryBufferData,
+        };
+        const binaryPropertyTable: BinaryPropertyTable = {
+          propertyTable: propertyTable,
+          binaryMetadata: binaryMetadata,
         };
         const propertyTableModel = new BinaryPropertyTableModel(
           binaryPropertyTable


### PR DESCRIPTION
This PR accompanies the PR at https://github.com/CesiumGS/3d-tiles-validator/pull/280 

The changes that are done here:

- The `GltfUtilities` contained a function `extractJsonFromGlb` that only sliced out the JSON buffer from a glTF 1.0 or glTF 2.0 GLB file. There was not function for obtaining the _binary_ buffer. This has been generalized into a function `extractDataFromGlb` that returns the JSON buffer _and_ the binary buffer.
- The `BinaryPropertyTable` originally contained the `propertyTable` and individual properties that together defined the _binary representation_ of the metadata (independent of whether it was part of a property table or not). The parts that define the binary metadata have now been summarized in a `BinaryMetadata` structure.
- The handling of `ENUM` properties and their binary representation had some issues that are supposed to be fixed here. Details are given in https://github.com/CesiumGS/3d-tiles-tools/issues/71 