### PR TITLE
Remove empty 'children' arrays during upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 0.?.? - 2023-mm-dd
+
+- The `upgrade` command is now removing empty `tile.children` arrays, setting the `children` to be `undefined` instead.
+
 ### 0.3.1 - 2023-10-10
 - Integrated a dedicated logging library (via [#61](https://github.com/CesiumGS/3d-tiles-tools/pull/61))
   - By default, only few, informative messages are logged to the console

--- a/specs/tilesetProcessing/TilesetUpgraderSpec.ts
+++ b/specs/tilesetProcessing/TilesetUpgraderSpec.ts
@@ -19,6 +19,8 @@ const unitBoundingBox = {
 //   (checked for both `content` and `contents`)
 // - The `extensionsUsed` and `extensionsRequired` should no
 //   longer contain `3DTILES_content_gltf`
+// - One tile has an empty 'children' array that should
+//   be removed
 const inputTilesetJsonRaw: unknown = {
   asset: {
     version: "0.0",
@@ -54,6 +56,11 @@ const inputTilesetJsonRaw: unknown = {
       {
         boundingVolume: unitBoundingBox,
         geometricError: 1.0,
+      },
+      {
+        boundingVolume: unitBoundingBox,
+        geometricError: 1.0,
+        children: [],
       },
     ],
   },
@@ -115,5 +122,18 @@ describe("TilesetUpgrader", function () {
 
     expect(tileset.extensionsUsed).not.toContain("3DTILES_content_gltf");
     expect(tileset.extensionsRequired).not.toContain("3DTILES_content_gltf");
+  });
+
+  it("removes an empty 'children' array", async function () {
+    const targetVersion = "1.1";
+    const tilesetUpgrader = new TilesetUpgrader(
+      targetVersion,
+      gltfUpgradeOptions
+    );
+
+    const tileset = JSON.parse(inputTilesetJsonString) as Tileset;
+    await tilesetUpgrader.upgradeTileset(tileset);
+
+    expect(tileset.root.children![2].children).toBeUndefined();
   });
 });

--- a/src/tilesetProcessing/TilesetUpgrader.ts
+++ b/src/tilesetProcessing/TilesetUpgrader.ts
@@ -73,6 +73,7 @@ export class TilesetUpgrader {
         upgradedAssetVersionNumber: "1.0",
         upgradeRefineCase: true,
         upgradeContentUrlToUri: true,
+        upgradeEmptyChildrenToUndefined: true,
 
         upgradeContentGltfExtensionDeclarations: false,
 
@@ -92,6 +93,8 @@ export class TilesetUpgrader {
         upgradedAssetVersionNumber: "1.1",
         upgradeRefineCase: true,
         upgradeContentUrlToUri: true,
+        upgradeEmptyChildrenToUndefined: true,
+
         upgradeContentGltfExtensionDeclarations: true,
 
         upgradeB3dmGltf1ToGltf2: false,

--- a/src/tilesetProcessing/upgrade/TilesetObjectUpgrader.ts
+++ b/src/tilesetProcessing/upgrade/TilesetObjectUpgrader.ts
@@ -53,6 +53,10 @@ export class TilesetObjectUpgrader {
       logger.debug(`Upgrading content.url to content.uri`);
       await this.upgradeEachContentUrlToUri(tileset);
     }
+    if (this.upgradeOptions.upgradeEmptyChildrenToUndefined) {
+      logger.debug(`Upgrading empty children arrays to be 'undefined'`);
+      await this.upgradeEmptyChildrenToUndefined(tileset);
+    }
     if (this.upgradeOptions.upgradeContentGltfExtensionDeclarations) {
       logger.debug(`Upgrading extension declarations`);
       Extensions.removeExtensionUsed(tileset, "3DTILES_content_gltf");
@@ -125,6 +129,23 @@ export class TilesetObjectUpgrader {
     logger.warn(
       "  The content does not have a 'uri' property (and no legacy 'url' property)"
     );
+  }
+
+  /**
+   * Upgrade each empty 'children' in any tile by deleting them and
+   * causing the children to become 'undefined'
+   *
+   * @param tileset - The tileset
+   */
+  private async upgradeEmptyChildrenToUndefined(tileset: Tileset) {
+    const root = tileset.root;
+    await Tiles.traverseExplicit(root, async (tilePath: Tile[]) => {
+      const tile = tilePath[tilePath.length - 1];
+      if (tile.children !== undefined && tile.children.length === 0) {
+        delete tile.children;
+      }
+      return true;
+    });
   }
 
   /**

--- a/src/tilesetProcessing/upgrade/TilesetUpgradeOptions.ts
+++ b/src/tilesetProcessing/upgrade/TilesetUpgradeOptions.ts
@@ -23,6 +23,10 @@ export type TilesetUpgradeOptions = {
   // to `content.uri`
   upgradeContentUrlToUri: boolean;
 
+  // Whether empty `tile.children` arrays should
+  // be removed and become `undefined`
+  upgradeEmptyChildrenToUndefined: true;
+
   // Indicates whether the `3DTILES_content_gltf` extension
   // declaration should be removed, as part of an upgrade
   // to 1.1, where glTF is supported without an extension


### PR DESCRIPTION
See https://github.com/CesiumGS/3d-tiles/issues/752 : 

Originally, the `upgrade` command did not modify empty `children: []` arrays in tiles. Now these are removed (i.e. they become `undefined`) during the upgrade.
