### PR TITLE
Maintenance 2023 10

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -80,6 +80,14 @@
     "url": "https://www.npmjs.com/package/gltfpack"
   },
   {
+    "name": "meshoptimizer",
+    "license": [
+      "MIT"
+    ],
+    "version": "0.19.0",
+    "url": "https://www.npmjs.com/package/meshoptimizer"
+  },
+  {
     "name": "minimist",
     "license": [
       "MIT"

--- a/etc/3d-tiles-tools.api.md
+++ b/etc/3d-tiles-tools.api.md
@@ -6,9 +6,32 @@
 
 /// <reference types="node" />
 
+import { Accessor } from '@gltf-transform/core';
+import { Database } from 'better-sqlite3';
+import { Document } from '@gltf-transform/core';
+import { Extension } from '@gltf-transform/core';
+import { ExtensionProperty } from '@gltf-transform/core';
+import { IProperty } from '@gltf-transform/core';
+import { Logger } from 'pino';
 import { NodeIO } from '@gltf-transform/core';
+import { Nullable } from '@gltf-transform/core';
 import { PathLike } from 'fs';
+import { Primitive } from '@gltf-transform/core';
+import { PropertyType } from '@gltf-transform/core';
+import { ReaderContext } from '@gltf-transform/core';
+import { Texture } from '@gltf-transform/core';
+import { TextureInfo } from '@gltf-transform/core';
 import { Transform } from '@gltf-transform/core';
+import { TypedArray } from '@gltf-transform/core';
+import { WriterContext } from '@gltf-transform/core';
+
+// @internal
+export class AccessorCreation {
+    static createAccessorArray(componentType: string, accessorValues: Iterable<number>): TypedArray;
+    static createAccessorFromProperty(document: Document, classProperty: ClassProperty, propertyModel: PropertyModel, numRows: number): Accessor;
+    static createAccessorFromValues(document: Document, classProperty: ClassProperty, accessorValues: Iterable<number>): Accessor;
+    static createAccessorValues(classProperty: ClassProperty, propertyModel: PropertyModel, numRows: number): Iterable<number>;
+}
 
 // @internal (undocumented)
 export class ArchiveFunctions3tz {
@@ -30,6 +53,11 @@ export class ArchiveFunctions3tz {
 }
 
 // @internal
+export class ArrayBuffers {
+    static fromBuffer(buffer: Buffer): ArrayBuffer;
+}
+
+// @internal
 export class ArrayValues {
     static anyDeepGreaterThan(a: any, b: any): boolean;
     static anyDeepLessThan(a: any, b: any): boolean;
@@ -48,6 +76,22 @@ export interface Asset extends RootProperty {
 }
 
 // @internal
+export class AttributeCompression {
+    static octDecode16(input: number[]): number[];
+    static octDecode8(input: number[]): number[];
+}
+
+// @internal
+export type AttributeInfo = {
+    componentsPerAttribute: number;
+    componentDatatype: string;
+    byteOffset: number;
+    byteStride: number;
+    normalized: boolean;
+    quantization?: QuantizationInfo;
+};
+
+// @internal
 export interface Availability extends RootProperty {
     availableCount?: number;
     bitstream?: number;
@@ -64,6 +108,113 @@ export interface AvailabilityInfo {
 export class AvailabilityInfos {
     static createChildSubtree(availability: Availability, bufferViewDatas: Buffer[], implicitTiling: TileImplicitTiling): AvailabilityInfo;
     static createTileOrContent(availability: Availability, bufferViewDatas: Buffer[], implicitTiling: TileImplicitTiling): AvailabilityInfo;
+}
+
+// @internal
+export interface B3dmFeatureTable extends FeatureTable {
+    BATCH_LENGTH: number;
+    RTC_CENTER?: BinaryBodyOffset | number[];
+}
+
+// @internal
+export class BasicTilesetProcessor extends TilesetProcessor {
+    constructor(processExternalTilesets?: boolean);
+    end(): Promise<void>;
+    forEachExplicitTile(callback: (tile: Tile) => Promise<void>): Promise<void>;
+    forEachTile(callback: TraversalCallback): Promise<void>;
+    forTileset(callback: (tileset: Tileset, schema: Schema | undefined) => Promise<Tileset>): Promise<void>;
+    processAllEntries(entryProcessor: TilesetEntryProcessor): Promise<void>;
+    processTileContentEntries(uriProcessor: (uri: string) => string, entryProcessor: TilesetEntryProcessor): Promise<void>;
+    static updateTileContent(tile: Tile, contentUris: string[]): void;
+}
+
+// @internal
+export class BasisEncoder {
+    static create(): Promise<BasisEncoder>;
+    encode(dst_basis_file_js_val: Uint8Array): any;
+    setCheckForAlpha(check_for_alpha_flag: boolean): any;
+    setCompressionLevel(comp_level: number): any;
+    setComputeStats(compute_stats_flag: boolean): any;
+    setCreateKTX2File(create_ktx2_file: boolean): any;
+    setDebug(debug_flag: boolean): any;
+    setEndpointRDOThresh(endpoint_rdo_thresh: number): any;
+    setForceAlpha(force_alpha_flag: boolean): any;
+    setKTX2SRGBTransferFunc(srgb_transfer_func: boolean): any;
+    setKTX2UASTCSupercompression(use_zstandard: boolean): any;
+    setMaxEndpointClusters(max_endpoint_clusters: number): any;
+    setMaxSelectorClusters(max_selector_clusters: number): any;
+    setMipFilter(mip_filter: number): any;
+    setMipGen(mip_gen_flag: boolean): any;
+    setMipRenormalize(mip_renormalize_flag: boolean): any;
+    setMipScale(mip_scale: number): any;
+    setMipSmallestDimension(mip_smallest_dimension: number): any;
+    setMipSRGB(mip_srgb_flag: boolean): any;
+    setMipWrapping(mip_wrapping_flag: boolean): any;
+    setNoEndpointRDO(no_endpoint_rdo_flag: boolean): any;
+    setNormalMap(): any;
+    setNoSelectorRDO(no_selector_rdo_flag: boolean): any;
+    setPackUASTCFlags(pack_uastc_flags: number): any;
+    setPerceptual(perceptual_flag: boolean): any;
+    setQualityLevel(quality_level: number): any;
+    setRDOUASTC(rdo_uastc: boolean): any;
+    setRDOUASTCDictSize(dict_size: number): any;
+    setRDOUASTCMaxAllowedRMSIncreaseRatio(rdo_uastc_max_allowed_rms_increase_ratio: number): any;
+    setRDOUASTCQualityScalar(rdo_quality: number): any;
+    setRDOUASTCSkipBlockRMSThresh(rdo_uastc_skip_block_rms_thresh: number): any;
+    setRenormalize(renormalize_flag: boolean): any;
+    setSelectorRDOThresh(selector_rdo_thresh: number): any;
+    setSliceSourceImage(slice_index: number, src_image_js_val: Uint8Array, width: number, height: number, src_image_is_png: boolean): any;
+    setSwizzle(r: number, g: number, b: number, a: number): any;
+    setTexType(tex_type: number): any;
+    setUASTC(uastc_flag: boolean): any;
+    setYFlip(y_flip_flag: boolean): any;
+}
+
+// @internal
+export interface BatchTable extends RootProperty {
+    // (undocumented)
+    [key: string]: BatchTableBinaryBodyReference | any[] | {
+        [key: string]: any;
+    } | undefined;
+}
+
+// @internal
+export interface BatchTableBinaryBodyReference extends RootProperty {
+    byteOffset: number;
+    componentType: string;
+    type: string;
+}
+
+// @internal
+export class BatchTableClassProperties {
+    static createClassProperty(batchTablePropertyName: string, batchTablePropertyValue: any): ClassProperty;
+}
+
+// @internal
+export class BatchTablePropertyTableModels {
+    static create(table: {
+        [key: string]: any;
+    }, binary: Buffer, externalProperties: {
+        [key: string]: PropertyModel;
+    }, numRows: number): PropertyTableModel;
+}
+
+// @internal
+export class BatchTables {
+    static obtainDracoProperties(batchTable: BatchTable): {
+        [key: string]: number;
+    };
+    static obtainDracoPropertyNames(batchTable: BatchTable): string[];
+}
+
+// @internal
+export class BatchTableSchemas {
+    static createSchema(identifier: string, batchTable: BatchTable): Schema | undefined;
+}
+
+// @internal
+export interface BinaryBodyOffset extends RootProperty {
+    byteOffset: number;
 }
 
 // @internal
@@ -139,6 +290,16 @@ export interface BinaryPropertyTable {
 }
 
 // @internal
+export class BinaryPropertyTableBuilder {
+    addProperties(properties: {
+        [key: string]: any[];
+    }): this;
+    addProperty(propertyName: string, propertyValues: any[]): this;
+    build(): BinaryPropertyTable;
+    static create(schema: Schema, propertyTableClass: string, propertyTableName: string): BinaryPropertyTableBuilder;
+}
+
+// @internal
 export class BinaryPropertyTableModel implements PropertyTableModel {
     constructor(binaryPropertyTable: BinaryPropertyTable);
     getClassProperty(propertyId: string): ClassProperty | undefined;
@@ -174,10 +335,80 @@ export class BinarySubtreeDataResolver {
 }
 
 // @internal
+export class BooleanArrayPropertyModel implements PropertyModel {
+    constructor(valuesBuffer: Buffer, arrayOffsetsBuffer: Buffer | undefined, arrayOffsetType: string, count: number | undefined);
+    getPropertyValue(index: number): boolean[];
+}
+
+// @internal
+export class BooleanPropertyModel implements PropertyModel {
+    constructor(valuesBuffer: Buffer);
+    getPropertyValue(index: number): boolean;
+}
+
+// @internal (undocumented)
+export type BoundingBox3D = {
+    min: Point3D;
+    max: Point3D;
+};
+
+// @internal
 export interface BoundingVolume extends RootProperty {
     box?: number[];
     region?: number[];
     sphere?: number[];
+}
+
+// @internal
+export class BoundingVolumes {
+    static computeBoundingBoxCorners(boundingBox: BoundingBox3D): Point3D[];
+    static computeBoundingBoxUnion(bb0: BoundingBox3D, bb1: BoundingBox3D): BoundingBox3D;
+    static createBoundingBoxForBoundingVolumeBox(boundingVolumeBox: number[]): BoundingBox3D;
+    static createBoundingVolumeBoxFromBoundingBox(boundingBox: BoundingBox3D): number[];
+    static createBoundingVolumeBoxFromGltfBoundingBox(boundingBox: BoundingBox3D): number[];
+    static createUnitCubeBoundingBox(): BoundingBox3D;
+    static createUnitCubeBoundingVolumeBox(): number[];
+    static max(p0: Point3D, p1: Point3D, result?: Point3D): Point3D;
+    static min(p0: Point3D, p1: Point3D, result?: Point3D): Point3D;
+    static translateBoundingBox(boundingBox: BoundingBox3D, translation: Point3D): {
+        min: Point3D;
+        max: Point3D;
+    };
+}
+
+// @internal
+export interface BoundingVolumeS2 extends RootProperty {
+    // (undocumented)
+    maximumHeight: number;
+    // (undocumented)
+    minimumHeight: number;
+    // (undocumented)
+    token: string;
+}
+
+// @internal
+export class BufferAvailabilityInfo implements AvailabilityInfo {
+    constructor(buffer: Buffer, length: number);
+    isAvailable(index: number): boolean;
+    get length(): number;
+}
+
+// @internal
+export class BufferedContentData implements ContentData {
+    constructor(uri: string, data: Buffer | null);
+    static create(uri: string): ContentData;
+    exists(): Promise<boolean>;
+    get extension(): string;
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: No member was found with name "data"
+    //
+    // (undocumented)
+    getData(): Promise<Buffer | null>;
+    // Warning: (ae-unresolved-inheritdoc-reference) The @inheritDoc reference could not be resolved: No member was found with name "magic"
+    //
+    // (undocumented)
+    getMagic(): Promise<Buffer>;
+    getParsedObject(): Promise<any>;
+    get uri(): string;
 }
 
 // @internal
@@ -238,6 +469,47 @@ export interface ClassProperty extends RootProperty {
 }
 
 // @internal
+export type ClassPropertyComponentType = "INT8" | "UINT8" | "INT16" | "UINT16" | "INT32" | "UINT32" | "INT64" | "UINT64" | "FLOAT32" | "FLOAT64";
+
+// @internal
+export type ClassPropertyType = "SCALAR" | "VEC2" | "VEC3" | "VEC4" | "MAT2" | "MAT3" | "MAT4" | "STRING" | "BOOLEAN" | "ENUM";
+
+// @internal
+export class Colors {
+    static standardRGB565ToNormalizedLinearRGBA(input: number): number[];
+    static standardRGBAToNormalizedLinearRGBA(input: number[]): number[];
+    static standardRGBToNormalizedLinearRGBA(input: number[]): number[];
+}
+
+// @internal
+export class ComponentDatatype {
+    static readonly BYTE = 5120;
+    static readonly DOUBLE = 5130;
+    static readonly FLOAT = 5126;
+    static fromTypedArray(array: Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array): number;
+    static getSizeInBytes(componentDatatype: number): number;
+    static readonly INT = 5124;
+    static readonly SHORT = 5122;
+    static toString(componentDatatype: number): "FLOAT" | "UNSIGNED_SHORT" | "BYTE" | "UNSIGNED_BYTE" | "SHORT" | "INT" | "UNSIGNED_INT" | "DOUBLE";
+    static readonly UNSIGNED_BYTE = 5121;
+    static readonly UNSIGNED_INT = 5125;
+    static readonly UNSIGNED_SHORT = 5123;
+}
+
+// @internal
+export interface CompositeTileData {
+    header: Header;
+    innerTileBuffers: Buffer[];
+}
+
+// @internal
+export class ConstantAvailabilityInfo implements AvailabilityInfo {
+    constructor(available: boolean, length: number);
+    isAvailable(index: number): boolean;
+    get length(): number;
+}
+
+// @internal
 export interface Content extends RootProperty {
     boundingVolume?: BoundingVolume;
     group?: number;
@@ -256,9 +528,92 @@ export interface ContentData {
 }
 
 // @internal
+export class ContentDataTypeChecks {
+    static createCheck(includedContentDataTypes: (string | undefined)[] | undefined, excludedContentDataTypes: (string | undefined)[] | undefined): (contentData: ContentData) => Promise<boolean>;
+    static createIncludedCheck(...contentDataTypes: string[]): (contentData: ContentData) => Promise<boolean>;
+    static createTypeCheck(includedContentDataTypes: (string | undefined)[] | undefined, excludedContentDataTypes: (string | undefined)[] | undefined): (contentDataType: string | undefined) => boolean;
+}
+
+// @internal
+export type ContentDataTypeEntry = {
+    predicate: (contentData: ContentData) => Promise<boolean>;
+    type: string;
+};
+
+// @internal
 export class ContentDataTypeRegistry {
     static findContentDataType(contentData: ContentData): Promise<string | undefined>;
     static findType(uri: string, data: Buffer): Promise<string | undefined>;
+}
+
+// @internal
+export class ContentDataTypes {
+    // (undocumented)
+    static readonly CONTENT_TYPE_3TZ = "CONTENT_TYPE_3TZ";
+    // (undocumented)
+    static readonly CONTENT_TYPE_B3DM = "CONTENT_TYPE_B3DM";
+    // (undocumented)
+    static readonly CONTENT_TYPE_CMPT = "CONTENT_TYPE_CMPT";
+    // (undocumented)
+    static readonly CONTENT_TYPE_GEOJSON = "CONTENT_TYPE_GEOJSON";
+    // (undocumented)
+    static readonly CONTENT_TYPE_GEOM = "CONTENT_TYPE_GEOM";
+    // (undocumented)
+    static readonly CONTENT_TYPE_GIF = "CONTENT_TYPE_GIF";
+    // (undocumented)
+    static readonly CONTENT_TYPE_GLB = "CONTENT_TYPE_GLB";
+    // (undocumented)
+    static readonly CONTENT_TYPE_GLTF = "CONTENT_TYPE_GLTF";
+    // (undocumented)
+    static readonly CONTENT_TYPE_I3DM = "CONTENT_TYPE_I3DM";
+    // (undocumented)
+    static readonly CONTENT_TYPE_JPEG = "CONTENT_TYPE_JPEG";
+    // (undocumented)
+    static readonly CONTENT_TYPE_PNG = "CONTENT_TYPE_PNG";
+    // (undocumented)
+    static readonly CONTENT_TYPE_PNTS = "CONTENT_TYPE_PNTS";
+    // (undocumented)
+    static readonly CONTENT_TYPE_SUBT = "CONTENT_TYPE_SUBT";
+    // (undocumented)
+    static readonly CONTENT_TYPE_TILESET = "CONTENT_TYPE_TILESET";
+    // (undocumented)
+    static readonly CONTENT_TYPE_VCTR = "CONTENT_TYPE_VCTR";
+}
+
+// @internal
+export class ContentError extends Error {
+    constructor(message: string);
+    // (undocumented)
+    toString: () => string;
+}
+
+// @internal
+export class ContentOps {
+    static b3dmToGlbBuffer(inputBuffer: Buffer): Buffer;
+    static cmptToGlbBuffers(inputBuffer: Buffer): Buffer[];
+    static glbToB3dmBuffer(inputBuffer: Buffer): Buffer;
+    static glbToI3dmBuffer(inputBuffer: Buffer): Buffer;
+    static i3dmToGlbBuffer(inputBuffer: Buffer): Buffer;
+    static optimizeB3dmBuffer(inputBuffer: Buffer, options: any): Promise<Buffer>;
+    static optimizeI3dmBuffer(inputBuffer: Buffer, options: any): Promise<Buffer>;
+}
+
+// @internal
+export class Contents {
+    static getUri(content: Content): string | undefined;
+}
+
+// @internal
+export class ContentUpgrades {
+    static upgradeB3dmGltf1ToGltf2(inputBuffer: Buffer, options: any): Promise<Buffer>;
+    static upgradeI3dmGltf1ToGltf2(inputBuffer: Buffer, options: any): Promise<Buffer>;
+}
+
+// @internal
+export class DataError extends Error {
+    constructor(message: string);
+    // (undocumented)
+    toString: () => string;
 }
 
 // @internal
@@ -268,6 +623,46 @@ export class DefaultMetadataEntityModel implements MetadataEntityModel {
     }, json: any);
     getPropertyValue(propertyId: string): any;
     getPropertyValueBySemantic(semantic: string): any;
+}
+
+// @internal
+export class DefaultPointCloud implements ReadablePointCloud {
+    addAttribute(name: string, type: string, componentType: string, attribute: Iterable<number>): void;
+    getAttributeComponentType(name: string): string | undefined;
+    getAttributes(): string[];
+    getAttributeType(name: string): string | undefined;
+    getAttributeValues(name: string): Iterable<number> | undefined;
+    getGlobalPosition(): [number, number, number] | undefined;
+    getNormalizedLinearColors(): Iterable<number[]> | undefined;
+    getNormalizedLinearGlobalColor(): [number, number, number, number] | undefined;
+    getNormals(): Iterable<number[]> | undefined;
+    getPositions(): Iterable<number[]>;
+    // (undocumented)
+    setGlobalPosition(globalPosition: [number, number, number] | undefined): void;
+    setNormalizedLinearColors(colors: Iterable<number[]>): void;
+    // (undocumented)
+    setNormalizedLinearGlobalColor(globalColor: [number, number, number, number] | undefined): void;
+    setNormals(normals: Iterable<number[]>): void;
+    setPositions(positions: Iterable<number[]>): void;
+}
+
+// @internal
+export class DefaultPropertyModel implements PropertyModel {
+    constructor(data: any[]);
+    getPropertyValue(index: number): any;
+}
+
+// @internal
+export class DefaultPropertyTableModel implements PropertyTableModel {
+    constructor(numRows: number);
+    addClassProperty(propertyId: string, classProperty: ClassProperty): void;
+    addPropertyModel(propertyId: string, propertyModel: PropertyModel): void;
+    getClassProperty(propertyId: string): ClassProperty | undefined;
+    getCount(): number;
+    getMetadataEntityModel(index: number): MetadataEntityModel;
+    getPropertyModel(propertyId: string): PropertyModel | undefined;
+    getPropertyNames(): string[];
+    getPropertyTableProperty(propertyId: string): PropertyTableProperty | undefined;
 }
 
 // @internal
@@ -284,11 +679,65 @@ export class DeveloperError extends Error {
 }
 
 // @internal
+export class DracoDecoder {
+    static create(): Promise<DracoDecoder>;
+    decodePointCloud(properties: {
+        [key: string]: number;
+    }, binary: Buffer): DracoDecoderResult;
+}
+
+// @internal
+export type DracoDecoderResult = {
+    [key: string]: {
+        attributeData: Buffer;
+        attributeInfo: AttributeInfo;
+    };
+};
+
+// @internal
+export class DracoError extends Error {
+    constructor(message: string);
+    // (undocumented)
+    toString: () => string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IElementStructuralMetadata" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class ElementStructuralMetadata extends ExtensionProperty<IElementStructuralMetadata> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // Warning: (ae-forgotten-export) The symbol "NAME" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    protected getDefaults(): Nullable<IElementStructuralMetadata>;
+    // (undocumented)
+    getIndex(): number;
+    // (undocumented)
+    getPropertyTable(): StructuralMetadataPropertyTable | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: [PropertyType.NODE];
+    // (undocumented)
+    propertyType: "ElementStructuralMetadata";
+    // (undocumented)
+    setIndex(index: number): this;
+    // (undocumented)
+    setPropertyTable(propertyTable: StructuralMetadataPropertyTable | null): this;
+}
+
+// @internal
 export interface EnumValue extends RootProperty {
     description?: string;
     name: string;
     value: number;
 }
+
+// @internal
+export type EnumValueType = "INT8" | "UINT8" | "INT16" | "UINT16" | "INT32" | "UINT32" | "INT64" | "UINT64";
 
 // @internal
 export class ExplicitTraversedTile implements TraversedTile {
@@ -316,6 +765,158 @@ export class ExplicitTraversedTiles {
 }
 
 // @internal
+export class Extensions {
+    static addExtensionRequired(extensible: Extensible, extension: string): void;
+    // Warning: (ae-forgotten-export) The symbol "Extensible" needs to be exported by the entry point index.d.ts
+    static addExtensionUsed(extensible: Extensible, extension: string): void;
+    // Warning: (ae-forgotten-export) The symbol "Extended" needs to be exported by the entry point index.d.ts
+    static containsExtension(extended: Extended, extension: string): boolean;
+    static removeExtension(extended: Extended, extension: string): void;
+    static removeExtensionRequired(extensible: Extensible, extension: string): void;
+    static removeExtensionUsed(extensible: Extensible, extension: string): void;
+}
+
+// @internal
+export class EXTInstanceFeatures extends Extension {
+    // (undocumented)
+    createFeatureId(): InstanceFeaturesFeatureId;
+    // (undocumented)
+    createInstanceFeatures(): InstanceFeatures;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    readonly extensionName = "EXT_instance_features";
+    // (undocumented)
+    read(context: ReaderContext): this;
+    // (undocumented)
+    write(context: WriterContext): this;
+}
+
+// @internal
+export class EXTMeshFeatures extends Extension {
+    // (undocumented)
+    createFeatureId(): MeshFeaturesFeatureId;
+    // (undocumented)
+    createFeatureIdTexture(): FeatureIdTexture;
+    // (undocumented)
+    createMeshFeatures(): MeshFeatures;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    readonly extensionName = "EXT_mesh_features";
+    // (undocumented)
+    read(context: ReaderContext): this;
+    // (undocumented)
+    write(context: WriterContext): this;
+}
+
+// @internal
+export class EXTStructuralMetadata extends Extension {
+    // (undocumented)
+    createClass(): StructuralMetadataClass;
+    // Warning: (ae-forgotten-export) The symbol "ClassDef" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    createClassFrom(classDef: ClassDef): StructuralMetadataClass;
+    // (undocumented)
+    createClassProperty(): StructuralMetadataClassProperty;
+    // Warning: (ae-forgotten-export) The symbol "ClassPropertyDef" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    createClassPropertyFrom(classPropertyDef: ClassPropertyDef): StructuralMetadataClassProperty;
+    // (undocumented)
+    createElementStructuralMetadata(): ElementStructuralMetadata;
+    // (undocumented)
+    createEnum(): StructuralMetadataEnum;
+    // Warning: (ae-forgotten-export) The symbol "EnumDef" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    createEnumFrom(enumDef: EnumDef): StructuralMetadataEnum;
+    // (undocumented)
+    createEnumValue(): StructuralMetadataEnumValue;
+    // Warning: (ae-forgotten-export) The symbol "EnumValueDef" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    createEnumValueFrom(enumValueDef: EnumValueDef): StructuralMetadataEnumValue;
+    // (undocumented)
+    createMeshPrimitiveStructuralMetadata(): MeshPrimitiveStructuralMetadata;
+    // (undocumented)
+    createPropertyAttribute(): StructuralMetadataPropertyAttribute;
+    // (undocumented)
+    createPropertyAttributeProperty(): StructuralMetadataPropertyAttributeProperty;
+    // (undocumented)
+    createPropertyTable(): StructuralMetadataPropertyTable;
+    // (undocumented)
+    createPropertyTableProperty(): StructuralMetadataPropertyTableProperty;
+    // (undocumented)
+    createPropertyTexture(): StructuralMetadataPropertyTexture;
+    // (undocumented)
+    createPropertyTextureProperty(): StructuralMetadataPropertyTextureProperty;
+    // (undocumented)
+    createSchema(): StructuralMetadataSchema;
+    // Warning: (ae-forgotten-export) The symbol "SchemaDef" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    createSchemaFrom(schemaDef: SchemaDef): StructuralMetadataSchema;
+    // (undocumented)
+    createStructuralMetadata(): StructuralMetadata;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    readonly extensionName = "EXT_structural_metadata";
+    prewrite(context: WriterContext, propertyType: PropertyType): this;
+    // (undocumented)
+    readonly prewriteTypes: PropertyType[];
+    // (undocumented)
+    read(context: ReaderContext): this;
+    // (undocumented)
+    write(context: WriterContext): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IFeatureIdTexture" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class FeatureIdTexture extends ExtensionProperty<IFeatureIdTexture> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // Warning: (ae-forgotten-export) The symbol "NAME_3" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    extensionName: typeof NAME_3;
+    // (undocumented)
+    getChannels(): number[];
+    // (undocumented)
+    protected getDefaults(): Nullable<IFeatureIdTexture> & {
+        channels: number[];
+        texture: null;
+        textureInfo: TextureInfo;
+    };
+    // (undocumented)
+    getTexture(): Texture | null;
+    // (undocumented)
+    getTextureInfo(): TextureInfo | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["FeatureId"];
+    // (undocumented)
+    propertyType: "FeatureIdTexture";
+    // (undocumented)
+    setChannels(channels: number[]): this;
+    // (undocumented)
+    setTexture(texture: Texture | null): this;
+}
+
+// @internal
+export interface FeatureTable extends RootProperty {
+}
+
+// @internal
+export interface FeatureTableBinaryBodyReference extends BinaryBodyOffset {
+    componentType?: string;
+}
+
+// @internal
 export class FileResourceResolver implements ResourceResolver {
     constructor(basePath: string);
     derive(uri: string): ResourceResolver;
@@ -324,9 +925,65 @@ export class FileResourceResolver implements ResourceResolver {
 }
 
 // @internal
+export class GltfPack {
+    static process(inputGlb: Buffer, options: GltfPackOptions): Promise<Buffer>;
+}
+
+// @internal
+export type GltfPackOptions = Partial<{
+    c: boolean;
+    cc: boolean;
+    si: number;
+    sa: boolean;
+    slb: boolean;
+    vp: number;
+    vt: number;
+    vn: number;
+    vc: number;
+    vpi: boolean;
+    vpn: boolean;
+    vpf: boolean;
+    at: number;
+    ar: number;
+    as: number;
+    af: number;
+    ac: boolean;
+    kn: boolean;
+    km: boolean;
+    ke: boolean;
+    mm: boolean;
+    mi: boolean;
+    cf: boolean;
+    noq: boolean;
+}>;
+
+// @internal
+export class GltfPipelineLegacy {
+    // (undocumented)
+    static process(gltf: any): Promise<void>;
+}
+
+// @internal
 export class GltfTransform {
     static getIO(): Promise<NodeIO>;
     static process(inputGlb: Buffer, ...transforms: Transform[]): Promise<Buffer>;
+}
+
+// @internal
+export interface GltfTransformPointCloud {
+    document: Document;
+    primitive: Primitive;
+}
+
+// @internal
+export class GltfTransformPointClouds {
+    static applyQuantization(document: Document, quantizePositions: boolean, quantizeNormals: boolean): Promise<void>;
+    static build(readablePointCloud: ReadablePointCloud, mayRequireAlpha: boolean): GltfTransformPointCloud;
+}
+
+// @internal
+export class GltfTransformTextures {
+    static createTransformTexturesToKtx(etc1sOptions: KtxEtc1sOptions, uastcOptions: KtxUastcOptions): Transform;
 }
 
 // @internal
@@ -344,6 +1001,36 @@ export class GltfUtilities {
 
 // @internal
 export interface Group extends MetadataEntity {
+}
+
+// @internal
+export interface Header {
+    gltfFormat?: number;
+    magic: string;
+    version: number;
+}
+
+// @internal
+export interface I3dmFeatureTable extends FeatureTable {
+    BATCH_ID?: FeatureTableBinaryBodyReference;
+    EAST_NORTH_UP?: boolean;
+    INSTANCES_LENGTH: number;
+    NORMAL_RIGHT?: FeatureTableBinaryBodyReference;
+    NORMAL_RIGHT_OCT32P?: FeatureTableBinaryBodyReference;
+    NORMAL_UP?: FeatureTableBinaryBodyReference;
+    NORMAL_UP_OCT32P?: FeatureTableBinaryBodyReference;
+    POSITION?: FeatureTableBinaryBodyReference;
+    POSITION_QUANTIZED?: FeatureTableBinaryBodyReference;
+    QUANTIZED_VOLUME_OFFSET?: BinaryBodyOffset | number[];
+    QUANTIZED_VOLUME_SCALE?: BinaryBodyOffset | number[];
+    RTC_CENTER?: BinaryBodyOffset | number[];
+    SCALE?: FeatureTableBinaryBodyReference;
+    SCALE_NON_UNIFORM?: FeatureTableBinaryBodyReference;
+}
+
+// @internal
+export class Ids {
+    static sanitize(identifier: string): string;
 }
 
 // @internal
@@ -402,6 +1089,79 @@ export interface IndexEntry {
     offset: bigint;
 }
 
+// Warning: (ae-forgotten-export) The symbol "IInstanceFeatures" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class InstanceFeatures extends ExtensionProperty<IInstanceFeatures> {
+    // (undocumented)
+    addFeatureId(featureId: InstanceFeaturesFeatureId): this;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // Warning: (ae-forgotten-export) The symbol "NAME_2" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    extensionName: typeof NAME_2;
+    // (undocumented)
+    protected getDefaults(): Nullable<IInstanceFeatures> & {
+        featureIds: never[];
+    };
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listFeatureIds(): InstanceFeaturesFeatureId[];
+    // (undocumented)
+    parentTypes: [PropertyType.NODE];
+    // (undocumented)
+    propertyType: "InstanceFeatures";
+    // (undocumented)
+    removeFeatureId(featureId: InstanceFeaturesFeatureId): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IFeatureId" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class InstanceFeaturesFeatureId extends ExtensionProperty<IFeatureId> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME_2;
+    // Warning: (ae-forgotten-export) The symbol "FeatureIdAttribute" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    getAttribute(): FeatureIdAttribute;
+    // (undocumented)
+    protected getDefaults(): Nullable<IFeatureId>;
+    // (undocumented)
+    getFeatureCount(): number;
+    // (undocumented)
+    getLabel(): string;
+    // (undocumented)
+    getNullFeatureId(): number;
+    // (undocumented)
+    getPropertyTable(): StructuralMetadataPropertyTable | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["InstanceFeatures"];
+    // (undocumented)
+    propertyType: "FeatureId";
+    // (undocumented)
+    setAttribute(attribute: FeatureIdAttribute): this;
+    // (undocumented)
+    setFeatureCount(featureCount: number): this;
+    // (undocumented)
+    setLabel(label: string): this;
+    // (undocumented)
+    setNullFeatureId(nullFeatureId: number): this;
+    // (undocumented)
+    setPropertyTable(propertyTable: StructuralMetadataPropertyTable | null): this;
+}
+
+// @internal
+export class InstanceFeaturesUtils {
+    static createInstanceFeaturesInfoString(document: Document): string;
+}
+
 // @internal
 export class Iterables {
     static filter<T>(iterable: Iterable<T>, include: (element: T) => boolean): Iterable<T>;
@@ -413,6 +1173,42 @@ export class Iterables {
 }
 
 // @internal
+export class KtxError extends Error {
+    constructor(message: string);
+    // (undocumented)
+    toString: () => string;
+}
+
+// @internal
+export type KtxEtc1sOptions = Partial<{
+    compressionLevel: number;
+    qualityLevel: number;
+    transferFunction: "SRGB" | "LINEAR";
+}>;
+
+// @internal
+export type KtxOptions = KtxEtc1sOptions & KtxUastcOptions & {
+    uastc: boolean;
+    computeStats?: boolean;
+    debug?: boolean;
+};
+
+// @internal
+export type KtxUastcOptions = Partial<{
+    level: number;
+    rdo_l: number;
+    rdo_d: number;
+    zstd: number;
+    transferFunction: "SRGB" | "LINEAR";
+}>;
+
+// @internal
+export class KtxUtility {
+    static convertImageData(inputImageData: Buffer, options: KtxOptions | undefined): Promise<Buffer>;
+    static convertImageFile(inputFileName: string, outputFileName: string, options: KtxOptions | undefined): Promise<void>;
+}
+
+// @internal
 export class LazyContentData implements ContentData {
     constructor(uri: string, resourceResolver: ResourceResolver);
     exists(): Promise<boolean>;
@@ -421,6 +1217,121 @@ export class LazyContentData implements ContentData {
     getMagic(): Promise<Buffer>;
     getParsedObject(): Promise<any>;
     get uri(): string;
+}
+
+// @internal
+export class Loggers {
+    static get(loggerName?: string): Logger;
+    static initDefaultLogger(prettyPrint?: boolean): void;
+    static setLevel(level: string): void;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IMeshFeatures" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class MeshFeatures extends ExtensionProperty<IMeshFeatures> {
+    // (undocumented)
+    addFeatureId(featureId: MeshFeaturesFeatureId): this;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME_3;
+    // (undocumented)
+    protected getDefaults(): Nullable<IMeshFeatures> & {
+        featureIds: never[];
+    };
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listFeatureIds(): MeshFeaturesFeatureId[];
+    // (undocumented)
+    parentTypes: [PropertyType.PRIMITIVE];
+    // (undocumented)
+    propertyType: "MeshFeatures";
+    // (undocumented)
+    removeFeatureId(featureId: MeshFeaturesFeatureId): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IFeatureId_2" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class MeshFeaturesFeatureId extends ExtensionProperty<IFeatureId_2> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME_3;
+    // Warning: (ae-forgotten-export) The symbol "FeatureIdAttribute_2" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    getAttribute(): FeatureIdAttribute_2;
+    // (undocumented)
+    protected getDefaults(): Nullable<IFeatureId_2>;
+    // (undocumented)
+    getFeatureCount(): number;
+    // (undocumented)
+    getLabel(): string;
+    // (undocumented)
+    getNullFeatureId(): number;
+    // (undocumented)
+    getPropertyTable(): StructuralMetadataPropertyTable | null;
+    // (undocumented)
+    getTexture(): FeatureIdTexture | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["MeshFeatures"];
+    // (undocumented)
+    propertyType: "FeatureId";
+    // (undocumented)
+    setAttribute(attribute: FeatureIdAttribute_2): this;
+    // (undocumented)
+    setFeatureCount(featureCount: number): this;
+    // (undocumented)
+    setLabel(label: string): this;
+    // (undocumented)
+    setNullFeatureId(nullFeatureId: number): this;
+    // (undocumented)
+    setPropertyTable(propertyTable: StructuralMetadataPropertyTable | null): this;
+    // (undocumented)
+    setTexture(texture: FeatureIdTexture | null): this;
+}
+
+// @internal
+export class MeshFeaturesUtils {
+    static createMeshFeaturesInfoString(document: Document): string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IMeshPrimitiveStructuralMetadata" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class MeshPrimitiveStructuralMetadata extends ExtensionProperty<IMeshPrimitiveStructuralMetadata> {
+    // (undocumented)
+    addPropertyAttribute(propertyAttribute: StructuralMetadataPropertyAttribute): this;
+    // (undocumented)
+    addPropertyTexture(propertyTexture: StructuralMetadataPropertyTexture): this;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    protected getDefaults(): Nullable<IMeshPrimitiveStructuralMetadata> & {
+        propertyTextures: never[];
+        propertyAttributes: never[];
+    };
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listPropertyAttributes(): StructuralMetadataPropertyAttribute[];
+    // (undocumented)
+    listPropertyTextures(): StructuralMetadataPropertyTexture[];
+    // (undocumented)
+    parentTypes: [PropertyType.PRIMITIVE];
+    // (undocumented)
+    propertyType: "MeshPrimitiveStructuralMetadata";
+    // (undocumented)
+    removePropertyAttribute(propertyAttribute: StructuralMetadataPropertyAttribute): this;
+    // (undocumented)
+    removePropertyTexture(propertyTexture: StructuralMetadataPropertyTexture): this;
 }
 
 // @internal
@@ -507,6 +1418,14 @@ export class MetadataError extends Error {
 }
 
 // @internal
+export class MetadataSemanticOverrides {
+    static applyExplicitContentMetadataSemanticOverrides(content: Content, schema: Schema): void;
+    static applyExplicitTileMetadataSemanticOverrides(tile: Tile, schema: Schema): void;
+    static applyImplicitContentMetadataSemanticOverrides(content: Content, contentSetIndex: number, tileIndex: number, subtreeMetadataModel: SubtreeMetadataModel): void;
+    static applyImplicitTileMetadataSemanticOverrides(tile: Tile, tileIndex: number, subtreeMetadataModel: SubtreeMetadataModel): void;
+}
+
+// @internal
 export class MetadataTypes {
     static allTypes: string[];
     // (undocumented)
@@ -556,11 +1475,34 @@ export class MetadataValues {
 }
 
 // @internal
+export class MortonOrder {
+    static encode2D(x: number, y: number): number;
+    static encode3D(x: number, y: number, z: number): number;
+}
+
+// @internal
+export class NumberTypeDescriptions {
+    static computeComponentType(value: number | bigint | number[] | bigint[] | number[][] | bigint[][]): string;
+}
+
+// @internal
+export class NumericArrayPropertyModel implements PropertyModel {
+    constructor(type: string, valuesBuffer: Buffer, componentType: string, arrayOffsetsBuffer: Buffer | undefined, arrayOffsetType: string, count: number | undefined);
+    getPropertyValue(index: number): (number | bigint | (number | bigint)[])[];
+}
+
+// @internal
 export class NumericBuffers {
     static getBooleanFromBuffer(buffer: Buffer, index: number): boolean;
     static getNumericArrayFromBuffer(buffer: Buffer, index: number, arrayLength: number, componentType: string): (number | bigint)[];
     static getNumericBufferAsArray(buffer: Buffer, componentType: string): any;
     static getNumericFromBuffer(buffer: Buffer, index: number, componentType: string): number | bigint;
+}
+
+// @internal
+export class NumericPropertyModel implements PropertyModel {
+    constructor(type: string, valuesBuffer: Buffer, componentType: string);
+    getPropertyValue(index: number): number | bigint | (number | bigint)[];
 }
 
 // @internal
@@ -602,6 +1544,35 @@ export class Paths {
 }
 
 // @internal
+export interface PntsFeatureTable extends FeatureTable {
+    BATCH_ID?: FeatureTableBinaryBodyReference;
+    BATCH_LENGTH?: number;
+    CONSTANT_RGBA?: BinaryBodyOffset | number[];
+    NORMAL?: FeatureTableBinaryBodyReference;
+    NORMAL_OCT16P?: FeatureTableBinaryBodyReference;
+    POINTS_LENGTH: number;
+    POSITION?: FeatureTableBinaryBodyReference;
+    POSITION_QUANTIZED?: FeatureTableBinaryBodyReference;
+    QUANTIZED_VOLUME_OFFSET?: BinaryBodyOffset | number[];
+    QUANTIZED_VOLUME_SCALE?: BinaryBodyOffset | number[];
+    RGB?: FeatureTableBinaryBodyReference;
+    RGB565?: FeatureTableBinaryBodyReference;
+    RGBA?: FeatureTableBinaryBodyReference;
+    RTC_CENTER?: BinaryBodyOffset | number[];
+}
+
+// @internal
+export class PntsPointClouds {
+    static create(featureTable: PntsFeatureTable, featureTableBinary: Buffer, batchTable: BatchTable): Promise<ReadablePointCloud>;
+    static hasOctEncodedNormals(featureTable: PntsFeatureTable): boolean;
+    static hasQuantizedPositions(featureTable: PntsFeatureTable): boolean;
+    static mayRequireAlpha(featureTable: PntsFeatureTable): boolean;
+}
+
+// @internal (undocumented)
+export type Point3D = [number, number, number];
+
+// @internal
 export interface Properties extends RootProperty {
     maximum: number;
     minimum: number;
@@ -610,6 +1581,13 @@ export interface Properties extends RootProperty {
 // @internal
 export interface PropertyModel {
     getPropertyValue(index: number): any;
+}
+
+// @internal
+export class PropertyModels {
+    static createIterable(propertyModel: PropertyModel, numElements: number): Iterable<any>;
+    static createNumericArrayIterable(propertyModel: PropertyModel, numElements: number): Iterable<number[]>;
+    static createNumericScalarIterable(propertyModel: PropertyModel, numElements: number): Iterable<number>;
 }
 
 // @internal
@@ -633,6 +1611,11 @@ export interface PropertyTableModel {
 }
 
 // @internal
+export class PropertyTableModels {
+    static createString(propertyTableModel: PropertyTableModel, maxRows?: number): string;
+}
+
+// @internal
 export interface PropertyTableProperty extends RootProperty {
     arrayOffsets?: number;
     arrayOffsetType?: string;
@@ -644,6 +1627,9 @@ export interface PropertyTableProperty extends RootProperty {
     stringOffsetType?: string;
     values: number;
 }
+
+// @internal
+export type PropertyTablePropertyOffsetType = "UINT8" | "UINT16" | "UINT32" | "UINT64";
 
 // @internal
 export class QuadtreeCoordinates implements TreeCoordinates {
@@ -668,6 +1654,27 @@ export class Quadtrees {
     static computeNumberOfNodesForLevels(levels: number): number;
     static coordinatesForLevel(level: number): Generator<QuadtreeCoordinates, void, unknown>;
     static isValid(c: QuadtreeCoordinates): boolean;
+}
+
+// @internal
+export type QuantizationInfo = {
+    quantizationBits: number;
+    minValues?: number[];
+    range?: number;
+    octEncoded: boolean;
+};
+
+// @internal
+export interface ReadablePointCloud {
+    getAttributeComponentType(name: string): string | undefined;
+    getAttributes(): string[];
+    getAttributeType(name: string): string | undefined;
+    getAttributeValues(name: string): Iterable<number> | undefined;
+    getGlobalPosition(): [number, number, number] | undefined;
+    getNormalizedLinearColors(): Iterable<number[]> | undefined;
+    getNormalizedLinearGlobalColor(): [number, number, number, number] | undefined;
+    getNormals(): Iterable<number[]> | undefined;
+    getPositions(): Iterable<number[]>;
 }
 
 // @internal
@@ -740,6 +1747,596 @@ export interface StatisticsClassProperty extends RootProperty {
 }
 
 // @internal
+export class StringArrayPropertyModel implements PropertyModel {
+    constructor(valuesBuffer: Buffer, arrayOffsetsBuffer: Buffer | undefined, arrayOffsetType: string, stringOffsetsBuffer: Buffer, stringOffsetType: string, count: number | undefined);
+    getPropertyValue(index: number): string[];
+}
+
+// @internal
+export class StringBuilder {
+    constructor();
+    // (undocumented)
+    addLine(...args: any[]): void;
+    // (undocumented)
+    decreaseIndent(): void;
+    // (undocumented)
+    increaseIndent(): void;
+    // (undocumented)
+    toString(): string;
+}
+
+// @internal
+export class StringPropertyModel implements PropertyModel {
+    constructor(valuesBuffer: Buffer, stringOffsetsBuffer: Buffer, stringOffsetType: string);
+    getPropertyValue(index: number): string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IStructuralMetadata" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadata extends ExtensionProperty<IStructuralMetadata> {
+    // (undocumented)
+    addPropertyAttribute(propertyAttribute: StructuralMetadataPropertyAttribute): this;
+    // (undocumented)
+    addPropertyTable(propertyTable: StructuralMetadataPropertyTable): this;
+    // (undocumented)
+    addPropertyTexture(propertyTexture: StructuralMetadataPropertyTexture): this;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    protected getDefaults(): Nullable<IStructuralMetadata> & {
+        propertyTables: never[];
+        propertyTextures: never[];
+        propertyAttributes: never[];
+    };
+    // (undocumented)
+    getSchema(): StructuralMetadataSchema | null;
+    // (undocumented)
+    getSchemaUri(): string;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listPropertyAttributes(): StructuralMetadataPropertyAttribute[];
+    // (undocumented)
+    listPropertyTables(): StructuralMetadataPropertyTable[];
+    // (undocumented)
+    listPropertyTextures(): StructuralMetadataPropertyTexture[];
+    // (undocumented)
+    parentTypes: [PropertyType.ROOT];
+    // (undocumented)
+    propertyType: "StructuralMetadata";
+    // (undocumented)
+    removePropertyAttribute(propertyAttribute: StructuralMetadataPropertyAttribute): this;
+    // (undocumented)
+    removePropertyTable(propertyTable: StructuralMetadataPropertyTable): this;
+    // (undocumented)
+    removePropertyTexture(propertyTexture: StructuralMetadataPropertyTexture): this;
+    // (undocumented)
+    setSchema(schema: StructuralMetadataSchema | null): this;
+    // (undocumented)
+    setSchemaUri(name: string): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IClass" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataClass extends ExtensionProperty<IClass> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    protected getDefaults(): Nullable<IClass> & {
+        properties: {};
+    };
+    // (undocumented)
+    getDescription(): string;
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getProperty(key: string): StructuralMetadataClassProperty | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listPropertyKeys(): string[];
+    // (undocumented)
+    listPropertyValues(): StructuralMetadataClassProperty[];
+    // (undocumented)
+    parentTypes: ["Schema"];
+    // (undocumented)
+    propertyType: "Class";
+    // (undocumented)
+    setDescription(description: string): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setProperty(key: string, value: StructuralMetadataClassProperty | null): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IClassProperty" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataClassProperty extends ExtensionProperty<IClassProperty> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getArray(): boolean;
+    // (undocumented)
+    getComponentType(): ClassPropertyComponentType;
+    // (undocumented)
+    getCount(): number;
+    // (undocumented)
+    getDefault(): any;
+    // (undocumented)
+    protected getDefaults(): Nullable<IClassProperty> & {
+        array: boolean;
+        normalized: boolean;
+        required: boolean;
+    };
+    // (undocumented)
+    getDescription(): string;
+    // (undocumented)
+    getEnumType(): string;
+    // (undocumented)
+    getMax(): any;
+    // (undocumented)
+    getMin(): any;
+    // (undocumented)
+    getNoData(): any;
+    // (undocumented)
+    getNormalized(): boolean;
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getOffset(): any;
+    // (undocumented)
+    getRequired(): boolean;
+    // (undocumented)
+    getScale(): any;
+    // (undocumented)
+    getType(): ClassPropertyType;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["Class"];
+    // (undocumented)
+    propertyType: "ClassProperty";
+    // (undocumented)
+    setArray(array: boolean): this;
+    // (undocumented)
+    setComponentType(componentType: ClassPropertyComponentType): this;
+    // (undocumented)
+    setCount(count: number): this;
+    // (undocumented)
+    setDefault(defaultValue: any): this;
+    // (undocumented)
+    setDescription(description: string): this;
+    // (undocumented)
+    setEnumType(enumType: string): this;
+    // (undocumented)
+    setMax(max: any): this;
+    // (undocumented)
+    setMin(min: any): this;
+    // (undocumented)
+    setNoData(noData: any): this;
+    // (undocumented)
+    setNormalized(normalized: boolean): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setOffset(offset: any): this;
+    // (undocumented)
+    setRequired(required: boolean): this;
+    // (undocumented)
+    setScale(scale: any): this;
+    // (undocumented)
+    setType(type: ClassPropertyType): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IEnum" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataEnum extends ExtensionProperty<IEnum> {
+    // (undocumented)
+    addEnumValue(enumValue: StructuralMetadataEnumValue): this;
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    protected getDefaults(): Nullable<IEnum> & {
+        valueType: string;
+        values: never[];
+    };
+    // (undocumented)
+    getDescription(): string;
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getValueType(): EnumValueType;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listValues(): StructuralMetadataEnumValue[];
+    // (undocumented)
+    parentTypes: ["Schema"];
+    // (undocumented)
+    propertyType: "Enum";
+    // (undocumented)
+    removeEnumValue(enumValue: StructuralMetadataEnumValue): this;
+    // (undocumented)
+    setDescription(description: string): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setValueType(valueType: EnumValueType): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IEnumValue" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataEnumValue extends ExtensionProperty<IEnumValue> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    protected getDefaults(): Nullable<IEnumValue>;
+    // (undocumented)
+    getDescription(): string;
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getValue(): number;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["Enum"];
+    // (undocumented)
+    propertyType: "EnumValue";
+    // (undocumented)
+    setDescription(description: string): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setValue(value: number): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IPropertyAttribute" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataPropertyAttribute extends ExtensionProperty<IPropertyAttribute> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getClass(): string;
+    // (undocumented)
+    protected getDefaults(): Nullable<IPropertyAttribute> & {
+        properties: {};
+    };
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getProperty(key: string): StructuralMetadataPropertyAttributeProperty | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listPropertyKeys(): string[];
+    // (undocumented)
+    listPropertyValues(): StructuralMetadataPropertyAttributeProperty[];
+    // (undocumented)
+    parentTypes: ["StructuralMetadata"];
+    // (undocumented)
+    propertyType: "PropertyAttribute";
+    // (undocumented)
+    setClass(_class: string): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setProperty(key: string, value: StructuralMetadataPropertyAttributeProperty | null): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IPropertyAttributeProperty" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataPropertyAttributeProperty extends ExtensionProperty<IPropertyAttributeProperty> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getAttribute(): string;
+    // (undocumented)
+    protected getDefaults(): Nullable<IPropertyAttributeProperty>;
+    // (undocumented)
+    getMax(): any;
+    // (undocumented)
+    getMin(): any;
+    // (undocumented)
+    getOffset(): any;
+    // (undocumented)
+    getScale(): any;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["PropertyAttribute"];
+    // (undocumented)
+    propertyType: "PropertyAttributeProperty";
+    // (undocumented)
+    setAttribute(attribute: string): this;
+    // (undocumented)
+    setMax(max: any): this;
+    // (undocumented)
+    setMin(min: any): this;
+    // (undocumented)
+    setOffset(offset: any): this;
+    // (undocumented)
+    setScale(scale: any): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IPropertyTable" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataPropertyTable extends ExtensionProperty<IPropertyTable> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getClass(): string;
+    // (undocumented)
+    getCount(): number;
+    // (undocumented)
+    protected getDefaults(): Nullable<IPropertyTable> & {
+        properties: {};
+    };
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getProperty(key: string): StructuralMetadataPropertyTableProperty | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listPropertyKeys(): string[];
+    // (undocumented)
+    listPropertyValues(): StructuralMetadataPropertyTableProperty[];
+    // (undocumented)
+    parentTypes: ["StructuralMetadata"];
+    // (undocumented)
+    propertyType: "PropertyTable";
+    // (undocumented)
+    setClass(className: string): this;
+    // (undocumented)
+    setCount(count: number): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setProperty(key: string, value: StructuralMetadataPropertyTableProperty | null): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IPropertyTableProperty" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataPropertyTableProperty extends ExtensionProperty<IPropertyTableProperty> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getArrayOffsets(): Uint8Array | null;
+    // (undocumented)
+    getArrayOffsetType(): PropertyTablePropertyOffsetType;
+    // (undocumented)
+    protected getDefaults(): Nullable<IPropertyTableProperty> & {
+        arrayOffsetType: string;
+        stringOffsetType: string;
+    };
+    // (undocumented)
+    getMax(): any;
+    // (undocumented)
+    getMin(): any;
+    // (undocumented)
+    getOffset(): any;
+    // (undocumented)
+    getScale(): any;
+    // (undocumented)
+    getStringOffsets(): Uint8Array | null;
+    // (undocumented)
+    getStringOffsetType(): PropertyTablePropertyOffsetType;
+    // (undocumented)
+    getValues(): Uint8Array;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["PropertyTable"];
+    // (undocumented)
+    propertyType: "PropertyTableProperty";
+    // (undocumented)
+    setArrayOffsets(arrayOffsets: Uint8Array): this;
+    // (undocumented)
+    setArrayOffsetType(arrayOffsetType: PropertyTablePropertyOffsetType): this;
+    // (undocumented)
+    setMax(max: any): this;
+    // (undocumented)
+    setMin(min: any): this;
+    // (undocumented)
+    setOffset(offset: any): this;
+    // (undocumented)
+    setScale(scale: any): this;
+    // (undocumented)
+    setStringOffsets(stringOffsets: Uint8Array): this;
+    // (undocumented)
+    setStringOffsetType(stringOffsetType: PropertyTablePropertyOffsetType): this;
+    // (undocumented)
+    setValues(values: Uint8Array): this;
+}
+
+// @internal
+export class StructuralMetadataPropertyTables {
+    static create(extStructuralMetadata: EXTStructuralMetadata, binaryPropertyTable: BinaryPropertyTable): StructuralMetadataPropertyTable;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IPropertyTexture" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataPropertyTexture extends ExtensionProperty<IPropertyTexture> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getClass(): string;
+    // (undocumented)
+    protected getDefaults(): Nullable<IPropertyTexture> & {
+        properties: {};
+    };
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getProperty(key: string): StructuralMetadataPropertyTextureProperty | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listPropertyKeys(): string[];
+    // (undocumented)
+    listPropertyValues(): StructuralMetadataPropertyTextureProperty[];
+    // (undocumented)
+    parentTypes: ["StructuralMetadata"];
+    // (undocumented)
+    propertyType: "PropertyTexture";
+    // (undocumented)
+    setClass(_class: string): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setProperty(key: string, value: StructuralMetadataPropertyTextureProperty | null): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "IPropertyTextureProperty" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataPropertyTextureProperty extends ExtensionProperty<IPropertyTextureProperty> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getChannels(): number[];
+    // (undocumented)
+    protected getDefaults(): Nullable<IPropertyTextureProperty> & {
+        channels: number[];
+        texture: null;
+        textureInfo: TextureInfo;
+    };
+    // (undocumented)
+    getMax(): any;
+    // (undocumented)
+    getMin(): any;
+    // (undocumented)
+    getOffset(): any;
+    // (undocumented)
+    getScale(): any;
+    // (undocumented)
+    getTexture(): Texture | null;
+    // (undocumented)
+    getTextureInfo(): TextureInfo | null;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    parentTypes: ["PropertyTexture"];
+    // (undocumented)
+    propertyType: "PropertyTextureProperty";
+    // (undocumented)
+    setChannels(channels: number[]): this;
+    // (undocumented)
+    setMax(max: any): this;
+    // (undocumented)
+    setMin(min: any): this;
+    // (undocumented)
+    setOffset(offset: any): this;
+    // (undocumented)
+    setScale(scale: any): this;
+    // (undocumented)
+    setTexture(texture: Texture | null): this;
+}
+
+// Warning: (ae-forgotten-export) The symbol "ISchema" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export class StructuralMetadataSchema extends ExtensionProperty<ISchema> {
+    // (undocumented)
+    static EXTENSION_NAME: string;
+    // (undocumented)
+    extensionName: typeof NAME;
+    // (undocumented)
+    getClass(key: string): StructuralMetadataClass | null;
+    // (undocumented)
+    protected getDefaults(): Nullable<ISchema> & {
+        classes: {};
+        enums: {};
+    };
+    // (undocumented)
+    getDescription(): string;
+    // (undocumented)
+    getEnum(key: string): StructuralMetadataEnum | null;
+    // (undocumented)
+    getId(): string;
+    // (undocumented)
+    getObjectName(): string;
+    // (undocumented)
+    getVersion(): string;
+    // (undocumented)
+    protected init(): void;
+    // (undocumented)
+    listClassKeys(): string[];
+    // (undocumented)
+    listClassValues(): StructuralMetadataClass[];
+    // (undocumented)
+    listEnumKeys(): string[];
+    // (undocumented)
+    listEnumValues(): StructuralMetadataEnum[];
+    // (undocumented)
+    parentTypes: ["StructuralMetadata"];
+    // (undocumented)
+    propertyType: "Schema";
+    // (undocumented)
+    setClass(key: string, value: StructuralMetadataClass | null): this;
+    // (undocumented)
+    setDescription(description: string): this;
+    // (undocumented)
+    setEnum(key: string, value: StructuralMetadataEnum | null): this;
+    // (undocumented)
+    setId(name: string): this;
+    // (undocumented)
+    setObjectName(name: string): this;
+    // (undocumented)
+    setVersion(version: string): this;
+}
+
+// @internal
+export class StructuralMetadataUtils {
+    static createStructuralMetadataInfoString(document: Document): string;
+}
+
+// @internal
+export interface Style extends RootProperty {
+    color?: string | string[];
+    defines?: {
+        [key: string]: string;
+    };
+    meta?: {
+        [key: string]: string;
+    };
+    show?: string | string[];
+}
+
+// @internal
 export interface Subtree extends RootProperty {
     buffers?: BufferObject[];
     bufferViews?: BufferView[];
@@ -797,6 +2394,39 @@ export interface Subtrees extends RootProperty {
 }
 
 // @internal
+export interface Table {
+    binary: Buffer;
+    json: any;
+}
+
+// @internal
+export class TableMetadataEntityModel implements MetadataEntityModel {
+    constructor(propertyTableModel: PropertyTableModel, entityIndex: number, semanticToPropertyId: {
+        [key: string]: string;
+    }, enumValueValueNames: {
+        [key: string]: {
+            [key: number]: string;
+        };
+    });
+    getPropertyValue(propertyId: string): any;
+    getPropertyValueBySemantic(semantic: string): any;
+}
+
+// @internal
+export type TableStructure = {
+    name: string;
+    columns: {
+        name: string;
+        type: string;
+    }[];
+};
+
+// @internal
+export class TableStructureValidator {
+    static validate(db: Database, tableStructure: TableStructure): string | undefined;
+}
+
+// @internal
 export class TemplateUris {
     static substituteOctree(templateUri: string, coordinates: OctreeCoordinates): string;
     static substituteOctreeInternal(templateUri: string, level: number, x: number, y: number, z: number): string;
@@ -819,11 +2449,162 @@ export interface Tile extends RootProperty {
 }
 
 // @internal
+export class TileContentProcessing {
+    static process(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean, tileContentProcessor: TileContentProcessor): Promise<void>;
+}
+
+// @internal
+export type TileContentProcessor = (content: Buffer, type: string | undefined) => Promise<Buffer>;
+
+// @internal
+export class TileContentProcessors {
+    static concat(...tileContentProcessors: TileContentProcessor[]): TileContentProcessor;
+}
+
+// @internal
+export class TileContentProcessorsGltfpack {
+    static create(options: GltfPackOptions): TileContentProcessor;
+}
+
+// @internal
+export class TileContentProcessorsGltfPipeline {
+    static create(options: any): TileContentProcessor;
+}
+
+// @internal
+export class TileContentProcessorsGltfTransform {
+    static create(...transforms: Transform[]): TileContentProcessor;
+}
+
+// @internal
+export class TileContentProcessorsTextures {
+    static encodeToKtx(etc1sOptions: KtxEtc1sOptions, uastcOptions: KtxUastcOptions): TileContentProcessor;
+}
+
+// @internal
+export interface TileData {
+    batchTable: Table;
+    featureTable: Table;
+    header: Header;
+    payload: Buffer;
+}
+
+// @internal
+export interface TileDataBlockLayout {
+    // (undocumented)
+    end: number;
+    // (undocumented)
+    length: number;
+    // (undocumented)
+    start: number;
+}
+
+// @internal
+export interface TileDataLayout {
+    // (undocumented)
+    batchTableBinary: TileDataBlockLayout;
+    // (undocumented)
+    batchTableJson: TileDataBlockLayout;
+    // (undocumented)
+    byteLength: number;
+    // (undocumented)
+    featureTableBinary: TileDataBlockLayout;
+    // (undocumented)
+    featureTableJson: TileDataBlockLayout;
+    // (undocumented)
+    headerLength: number;
+    // (undocumented)
+    legacyBatchLength: number | undefined;
+    // (undocumented)
+    magic: string;
+    // (undocumented)
+    payload: TileDataBlockLayout;
+}
+
+// @internal
+export class TileDataLayouts {
+    // (undocumented)
+    static create(buffer: Buffer): TileDataLayout;
+}
+
+// @internal
+export class TileFormatError extends Error {
+    constructor(message: string);
+    // (undocumented)
+    toString: () => string;
+}
+
+// @internal
+export class TileFormats {
+    static createB3dmTileDataFromGlb(glbData: Buffer, featureTableJson: B3dmFeatureTable | undefined, featureTableBinary: Buffer | undefined, batchTableJson: BatchTable | undefined, batchTableBinary: Buffer | undefined): TileData;
+    static createCompositeTileData(tileDatas: TileData[]): CompositeTileData;
+    static createCompositeTileDataBuffer(compositeTileData: CompositeTileData): Buffer;
+    static createDefaultB3dmTileDataFromGlb(glbData: Buffer): TileData;
+    static createDefaultI3dmTileDataFromGlb(glbData: Buffer): TileData;
+    static createI3dmTileDataFromGlb(glbData: Buffer, featureTableJson: I3dmFeatureTable | undefined, featureTableBinary: Buffer | undefined, batchTableJson: BatchTable | undefined, batchTableBinary: Buffer | undefined): TileData;
+    static createTileDataBuffer(tileData: TileData): Buffer;
+    static extractGlbBuffers(tileDataBuffer: Buffer): Buffer[];
+    static extractTileData(buffer: Buffer, tileDataLayout: TileDataLayout): {
+        header: {
+            magic: string;
+            version: number;
+            gltfFormat: number | undefined;
+        };
+        featureTable: {
+            json: any;
+            binary: Buffer;
+        };
+        batchTable: {
+            json: any;
+            binary: Buffer;
+        };
+        payload: Buffer;
+    };
+    static isComposite(buffer: Buffer): boolean;
+    static readCompositeTileData(buffer: Buffer): CompositeTileData;
+    static readTileData(buffer: Buffer): TileData;
+}
+
+// @internal
+export class TileFormatsMigration {
+    static applyRtcCenter(document: Document, rtcCenter: number[]): void;
+    static convertB3dmToGlb(b3dmBuffer: Buffer): Promise<Buffer>;
+    static convertI3dmToGlb(i3dmBuffer: Buffer, externalGlbResolver: (uri: string) => Promise<Buffer | undefined>): Promise<Buffer>;
+    static convertPntsToGlb(pntsBuffer: Buffer): Promise<Buffer>;
+    // (undocumented)
+    static readonly DEBUG_LOG_FILE_CONTENT = false;
+    static makeSingleRoot(document: Document): void;
+}
+
+// @internal
+export class TileFormatsMigrationB3dm {
+    static convertB3dmToGlb(b3dmBuffer: Buffer): Promise<Buffer>;
+}
+
+// @internal
+export class TileFormatsMigrationI3dm {
+    static convertI3dmToGlb(i3dmBuffer: Buffer, externalGlbResolver: (uri: string) => Promise<Buffer | undefined>): Promise<Buffer>;
+}
+
+// @internal
+export class TileFormatsMigrationPnts {
+    static convertPntsToGlb(pntsBuffer: Buffer): Promise<Buffer>;
+}
+
+// @internal
 export interface TileImplicitTiling extends RootProperty {
     availableLevels: number;
     subdivisionScheme: string;
     subtreeLevels: number;
     subtrees: Subtrees;
+}
+
+// @internal
+export class Tiles {
+    static getContents(tile: Tile): Content[];
+    static getContentUris(tile: Tile): string[];
+    static setContents(tile: Tile, contents: Content[]): void;
+    static traverseExplicit(tile: Tile, callback: TileTraversalCallback): Promise<void>;
 }
 
 // @internal
@@ -844,16 +2625,119 @@ export interface Tileset extends RootProperty {
 }
 
 // @internal
+export class TilesetCombiner {
+    constructor(externalTilesetDetector: (contentData: ContentData) => Promise<boolean>);
+    combine(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean): Promise<void>;
+}
+
+// @internal
+export class TilesetConverter {
+    static convert(input: string, inputTilesetJsonFileName: string | undefined, output: string, force: boolean): Promise<void>;
+}
+
+// @internal
+export class TilesetDataProcessor extends TilesetProcessor {
+    processAllEntries(entryProcessor: TilesetEntryProcessor): Promise<void>;
+}
+
+// @internal
 export interface TilesetEntry {
     key: string;
     value: Buffer;
 }
 
 // @internal
+export type TilesetEntryProcessor = (sourceEntry: TilesetEntry, type: string | undefined) => Promise<TilesetEntry | undefined>;
+
+// @internal
 export class TilesetError extends Error {
     constructor(message: string);
     // (undocumented)
     toString: () => string;
+}
+
+// @internal
+export class TilesetInMemory implements TilesetSource, TilesetTarget {
+    constructor();
+    addEntry(key: string, content: Buffer): void;
+    begin(fullOutputName: string, overwrite: boolean): void;
+    close(): void;
+    end(): Promise<void>;
+    getKeys(): string[];
+    getValue(key: string): Buffer | undefined;
+    open(fullInputName: string): void;
+}
+
+// @internal
+export class TilesetJsonCreator {
+    static createTilesetFromContents(baseDir: string, contentUris: string[]): Promise<Tileset>;
+}
+
+// @internal
+export class TilesetMerger {
+    constructor();
+    merge(tilesetSourceNames: string[], tilesetTargetName: string, overwrite: boolean): Promise<void>;
+}
+
+// @internal
+export class TilesetObjectUpgrader {
+    constructor(upgradeOptions: TilesetUpgradeOptions);
+    upgradeTilesetObject(tileset: Tileset): Promise<void>;
+}
+
+// @internal
+export class TilesetProcessing {
+    static getSourceValue(tilesetSource: TilesetSource, key: string): Buffer;
+    static parseSourceValue<T>(tilesetSource: TilesetSource, key: string): T;
+    static resolveSchema(tilesetSource: TilesetSource, tileset: Tileset): Schema | undefined;
+}
+
+// @internal
+export abstract class TilesetProcessor {
+    begin(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean): Promise<void>;
+    end(): Promise<void>;
+    fetchSourceEntry(key: string): Promise<TilesetEntry | undefined>;
+    protected getContext(): TilesetProcessorContext;
+    protected getTargetKey(sourceKey: string): string | undefined;
+    isProcessed(key: string): boolean;
+    markAsProcessed(key: string): void;
+    protected processAllEntriesInternal(entryProcessor: TilesetEntryProcessor): Promise<void>;
+    processEntry(sourceKey: string, entryProcessor: TilesetEntryProcessor): Promise<void>;
+    protected putTargetKey(sourceKey: string, targetKey: string): void;
+    storeTargetEntries(...targetEntries: TilesetEntry[]): void;
+}
+
+// @internal
+export interface TilesetProcessorContext {
+    processedKeys: {
+        [key: string]: boolean;
+    };
+    schema: Schema | undefined;
+    sourceTileset: Tileset;
+    targetKeys: {
+        [key: string]: string;
+    };
+    targetTileset: Tileset;
+    tilesetSource: TilesetSource;
+    tilesetSourceJsonFileName: string;
+    tilesetTarget: TilesetTarget;
+    tilesetTargetJsonFileName: string;
+}
+
+// @internal
+export class TilesetProcessorContexts {
+    static close(context: TilesetProcessorContext): Promise<void>;
+    static create(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean): Promise<TilesetProcessorContext>;
+}
+
+// @internal
+export class Tilesets {
+    static areEqualPackages(tilesetPackageName0: string, tilesetPackageName1: string): boolean;
+    static combine(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean): Promise<void>;
+    static determineTilesetJsonFileName(tilesetDataName: string): string;
+    static merge(tilesetSourceNames: string[], tilesetTargetName: string, overwrite: boolean): Promise<void>;
+    static upgrade(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean, targetVersion: string, gltfUpgradeOptions: any): Promise<void>;
+    static upgradeTileset(tileset: Tileset, targetVersion: string): Promise<void>;
 }
 
 // @internal
@@ -955,6 +2839,93 @@ export class TilesetTraverser {
 }
 
 // @internal
+export class TilesetTraversers {
+    static createExternalTilesetRoots(baseUri: string, traversedTile: TraversedTile): Promise<TraversedTile[]>;
+    static resolveSchema(tileset: Tileset, resourceResolver: ResourceResolver): Promise<Schema | undefined>;
+}
+
+// @internal
+export type TilesetUpgradeOptions = {
+    upgradeExternalTilesets: boolean;
+    upgradedAssetVersionNumber: string;
+    upgradeRefineCase: boolean;
+    upgradeContentUrlToUri: boolean;
+    upgradeEmptyChildrenToUndefined: true;
+    upgradeContentGltfExtensionDeclarations: boolean;
+    upgradeB3dmGltf1ToGltf2: boolean;
+    upgradeI3dmGltf1ToGltf2: boolean;
+    upgradePntsToGlb: boolean;
+    upgradeB3dmToGlb: boolean;
+    upgradeI3dmToGlb: boolean;
+};
+
+// @internal
+export class TilesetUpgrader {
+    constructor(targetVersion: string, gltfUpgradeOptions: any);
+    upgrade(tilesetSourceName: string, tilesetTargetName: string, overwrite: boolean): Promise<void>;
+    upgradeTileset(tileset: Tileset): Promise<void>;
+}
+
+// @internal
+export class TileTableData {
+    static convertLegacyComponentTypeToComponentType(legacyComponentType: string): "UINT16" | "INT8" | "UINT8" | "INT16" | "INT32" | "UINT32" | "FLOAT32" | "FLOAT64";
+    static convertLegacyTypeToType(legacyType: string): "SCALAR" | "VEC2" | "VEC3" | "VEC4";
+    static createBatchIdsFromBinary(binary: Buffer, byteOffset: number, legacyComponentType: string, numPoints: number): Iterable<number>;
+    static createNumericArrayIterable(legacyType: string, legacyComponentType: string, binary: Buffer, byteOffset: number, numElements: number): Iterable<number[]>;
+    static createNumericPropertyModel(legacyType: string, legacyComponentType: string, binary: Buffer, byteOffset: number): PropertyModel;
+    static createNumericScalarIterable(legacyType: string, legacyComponentType: string, binary: Buffer, byteOffset: number, numElements: number): Iterable<number>;
+    static createPositions(featureTable: PntsFeatureTable | I3dmFeatureTable, binary: Buffer, numPositions: number): Iterable<number[]>;
+    static createPositionsFromBinary(binary: Buffer, byteOffset: number, numPositions: number): Iterable<number[]>;
+    static isBatchTableBinaryBodyReference(p: any): p is BatchTableBinaryBodyReference;
+    static obtainBatchIdComponentType(featureTable: PntsFeatureTable | I3dmFeatureTable): string | undefined;
+    static obtainGlobalPosition(featureTable: PntsFeatureTable | I3dmFeatureTable, featureTableBinary: Buffer): [number, number, number] | undefined;
+    static obtainNumberArray(binary: Buffer, property: number[] | BinaryBodyOffset, length: number, componentType: string): number[];
+    static obtainQuantizationOffsetScale(featureTable: PntsFeatureTable | I3dmFeatureTable, featureTableBinary: Buffer): {
+        offset: number[];
+        scale: number[];
+    } | undefined;
+    static obtainRtcCenter(rtcCenter: BinaryBodyOffset | number[], binary: Buffer): [number, number, number];
+}
+
+// @internal
+export class TileTableDataI3dm {
+    static createBatchIds(featureTable: I3dmFeatureTable, binary: Buffer): Iterable<number> | undefined;
+    static createInstanceMatrices(featureTable: I3dmFeatureTable, featureTableBinary: Buffer, numInstances: number): number[][];
+    static createMatrices(translations3D: Iterable<number[]>, rotationQuaternions: Iterable<number[]> | undefined, scales3D: Iterable<number[]> | undefined, numInstances: number): number[][];
+    static createNormalsUp(featureTable: I3dmFeatureTable, binary: Buffer, numElements: number): Iterable<number[]> | undefined;
+    static createRotationQuaternions(featureTable: I3dmFeatureTable, featureTableBinary: Buffer, numInstances: number): Iterable<number[]> | undefined;
+    static createScales3D(featureTable: I3dmFeatureTable, featureTableBinary: Buffer, numInstances: number): Iterable<number[]> | undefined;
+    static createWorldPositions(featureTable: I3dmFeatureTable, featureTableBinary: Buffer, numInstances: number): Iterable<number[]>;
+}
+
+// @internal
+export class TileTableDataPnts {
+    static createBatchIds(featureTable: PntsFeatureTable, binary: Buffer): Iterable<number> | undefined;
+    static createColorsStandardRGBAFromBinary(binary: Buffer, byteOffset: number, numElements: number): Iterable<number[]>;
+    static createColorsStandardRGBFromBinary(binary: Buffer, byteOffset: number, numElements: number): Iterable<number[]>;
+    static createGlobalNormalizedLinearColor(featureTable: PntsFeatureTable, binary: Buffer): [number, number, number, number] | undefined;
+    static createNormalizedLinearColors(featureTable: PntsFeatureTable, binary: Buffer, numElements: number): Iterable<number[]> | undefined;
+    static createNormals(featureTable: PntsFeatureTable, binary: Buffer, numElements: number): Iterable<number[]> | undefined;
+    static createNormalsFromBinary(binary: Buffer, byteOffset: number, numElements: number): Iterable<number[]>;
+}
+
+// @internal
+export class TileTableDataToMeshFeatures {
+    static convertBatchIdToMeshFeatures(document: Document, primitive: Primitive): MeshFeaturesFeatureId;
+}
+
+// @internal
+export class TileTableDataToStructuralMetadata {
+    static assignPerPointProperties(document: Document, primitive: Primitive, batchTable: BatchTable, batchTableBinary: Buffer, externalProperties: {
+        [key: string]: PropertyModel;
+    }, numRows: number): void;
+    static convertBatchTableToPropertyTable(document: Document, batchTable: BatchTable, batchTableBinary: Buffer, numRows: number): StructuralMetadataPropertyTable | undefined;
+}
+
+// @internal
+export type TileTraversalCallback = (tilePath: Tile[]) => Promise<boolean>;
+
+// @internal
 export interface TraversalCallback {
     (traversedTile: TraversedTile): Promise<boolean>;
 }
@@ -992,6 +2963,14 @@ export interface TreeCoordinates {
 }
 
 // @internal
+export class TypeDetection {
+    static computeCommonArrayLegth(value: any[][]): number | undefined;
+    static computeCommonComponentType(array: number[] | bigint[] | number[][] | bigint[][]): string;
+    static computeCommonType(array: any[]): string | undefined;
+    static containsOnlyArrays(value: any[]): boolean;
+}
+
+// @internal
 export class UnzippingResourceResolver implements ResourceResolver {
     constructor(delegate: ResourceResolver);
     derive(uri: string): ResourceResolver;
@@ -1003,6 +2982,25 @@ export class UnzippingResourceResolver implements ResourceResolver {
 export class Uris {
     static isAbsoluteUri(uri: string): boolean;
     static isDataUri(uri: string): boolean;
+}
+
+// @internal
+export class VecMath {
+    static add(a: number[], b: number[], result?: number[]): number[];
+    static composeMatrixTRS(translation3D: number[], rotationQuaternion?: number[], scale3D?: number[]): number[];
+    static computeEastNorthUpMatrix4(positionPacked: number[]): number[];
+    static computeMean3D(points: Iterable<number[]>): number[];
+    static computeRotationQuaternions(upVectors: number[][], rightVectors: number[][]): number[][];
+    static createYupToZupPacked4(): number[];
+    static createZupToYupPacked4(): number[];
+    static decomposeMatrixTRS(matrix4Packed: number[]): {
+        t: number[];
+        r: number[];
+        s: number[];
+    };
+    static matrix4ToQuaternion(matrix4Packed: number[]): number[];
+    static multiplyAll4(matrices4Packed: number[][]): number[];
+    static subtract(a: number[], b: number[], result?: number[]): number[];
 }
 
 // @internal (undocumented)
@@ -1017,6 +3015,11 @@ export interface ZipLocalFileHeader {
     filename_size: number;
     // (undocumented)
     signature: number;
+}
+
+// @internal
+export class ZipToPackage {
+    static convert(inputFileName: string, inputTilesetJsonFileName: string, outputFileName: string, overwrite: boolean): Promise<void>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/specs/tilesetProcessing/BasicTilesetProcessorSpec.ts
+++ b/specs/tilesetProcessing/BasicTilesetProcessorSpec.ts
@@ -22,7 +22,6 @@ const externalInput = "./specs/data/tilesetProcessing/externalProcessing";
 const externalOutput =
   "./specs/data/output/tilesetProcessing/externalProcessing";
 
-const quiet = true;
 const overwrite = true;
 
 /**
@@ -36,7 +35,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
   });
 
   it("forEachExplicitTile covers all explicit tiles", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput, overwrite);
 
     const actualContentUris: string[][] = [];
@@ -58,7 +57,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
   });
 
   it("forEachTile covers all tiles", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput, overwrite);
 
     const actualContentUris: string[][] = [];
@@ -81,7 +80,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
   });
 
   it("processTileContentEntries processes the tile content entries", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput, overwrite);
     const specEntryProcessor = new SpecEntryProcessor();
     await tilesetProcessor.processTileContentEntries(
@@ -118,7 +117,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
   });
 
   it("processTileContentEntries processes the tile content entries for external tilesets", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(externalInput, externalOutput, overwrite);
     const specEntryProcessor = new SpecEntryProcessor();
     await tilesetProcessor.processTileContentEntries(
@@ -217,7 +216,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
   });
 
   it("processTileContentEntries updates the content URIs", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput, overwrite);
     const specEntryProcessor = new SpecEntryProcessor();
     await tilesetProcessor.processTileContentEntries(
@@ -246,7 +245,7 @@ describe("BasicTilesetProcessor on explicit input", function () {
   });
 
   it("processTileContentEntries updates the tile contents", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput, overwrite);
 
     const inputTilesetJsonBuffer = fs.readFileSync(

--- a/specs/tilesetProcessing/ImplicitTilesetProcessorSpec.ts
+++ b/specs/tilesetProcessing/ImplicitTilesetProcessorSpec.ts
@@ -16,7 +16,6 @@ import { TilesetSources } from "../../src/tilesetData/TilesetSources";
 const implicitInput = "./specs/data/tilesetProcessing/implicitProcessing";
 const implicitOutput =
   "./specs/data/output/tilesetProcessing/implicitProcessing";
-const quiet = true;
 const overwrite = true;
 
 /**
@@ -30,7 +29,7 @@ describe("BasicTilesetProcessor on implicit input", function () {
   });
 
   it("forEachExplicitTile covers all explicit tiles", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(implicitInput, implicitOutput, overwrite);
 
     // There is only one explicit tile in the 'implicitProcessing' data
@@ -46,7 +45,7 @@ describe("BasicTilesetProcessor on implicit input", function () {
   });
 
   it("forEachTile covers all tiles", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(implicitInput, implicitOutput, overwrite);
 
     const actualContentUris: string[][] = [];
@@ -67,7 +66,7 @@ describe("BasicTilesetProcessor on implicit input", function () {
   });
 
   it("processTileContentEntries processes the tile content entries", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(implicitInput, implicitOutput, overwrite);
     const specEntryProcessor = new SpecEntryProcessor();
     await tilesetProcessor.processTileContentEntries(
@@ -88,7 +87,7 @@ describe("BasicTilesetProcessor on implicit input", function () {
   });
 
   it("processTileContentEntries updates the content URIs", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(implicitInput, implicitOutput, overwrite);
     const specEntryProcessor = new SpecEntryProcessor();
     await tilesetProcessor.processTileContentEntries(

--- a/specs/tilesetProcessing/PackageTilesetProcessorSpec.ts
+++ b/specs/tilesetProcessing/PackageTilesetProcessorSpec.ts
@@ -22,7 +22,6 @@ const implicitOutput = outputRoot + "implicitProcessing";
 const implicitOutput3tz = outputRoot + "implicitProcessing.3tz";
 const implicitOutput3dtiles = outputRoot + "implicitProcessing.3dtiles";
 
-const quiet = true;
 const overwrite = true;
 
 /**
@@ -35,7 +34,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes basic from directories to 3TZ", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput3tz, overwrite);
     await tilesetProcessor.end();
 
@@ -47,7 +46,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes basic from 3TZ to directories", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput3tz, basicOutput, overwrite);
     await tilesetProcessor.end();
 
@@ -59,7 +58,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes basic from directories to 3DTILES", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput, basicOutput3dtiles, overwrite);
     await tilesetProcessor.end();
 
@@ -71,7 +70,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes basic from 3DTILES to directories", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(basicInput3dtiles, basicOutput, overwrite);
     await tilesetProcessor.end();
 
@@ -83,7 +82,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes implicit from directories to 3TZ", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(implicitInput, implicitOutput3tz, overwrite);
     await tilesetProcessor.end();
 
@@ -95,7 +94,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes implicit from 3TZ to directories", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(implicitInput3tz, implicitOutput, overwrite);
     await tilesetProcessor.end();
 
@@ -107,7 +106,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes implicit from directories to 3DTILES", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(
       implicitInput,
       implicitOutput3dtiles,
@@ -123,7 +122,7 @@ describe("BasicTilesetProcessor on packages", function () {
   });
 
   it("writes implicit from 3DTILES to directories", async function () {
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(
       implicitInput3dtiles,
       implicitOutput,

--- a/src/contentProcessing/GltfTransformTextures.ts
+++ b/src/contentProcessing/GltfTransformTextures.ts
@@ -178,9 +178,9 @@ export class GltfTransformTextures {
    *
    * The `KHR_texture_basisu` specification carries an implementation note:
    *
-   * > As a general rule, textures with color data should use ETC1S while
-   * > textures with non-color data (such as roughness-metallic or
-   * > normal maps) should use UASTC.
+   * "As a general rule, textures with color data should use ETC1S while
+   * textures with non-color data (such as roughness-metallic or
+   * normal maps) should use UASTC.""
    *
    * Based on this, this method returns `true` iff one of the "slots"
    * that the texture is associated with is `normalTexture`,

--- a/src/contentProcessing/draco/ComponentDataType.ts
+++ b/src/contentProcessing/draco/ComponentDataType.ts
@@ -58,7 +58,7 @@ export class ComponentDatatype {
   /**
    * Returns the size, in bytes, of the corresponding datatype.
    *
-   * @param componentDatatype The component datatype to get the size of.
+   * @param componentDatatype - The component datatype to get the size of.
    * @returns The size in bytes.
    *
    * @throws DracoError when componentDatatype is not a valid value.
@@ -135,7 +135,7 @@ export class ComponentDatatype {
   /**
    * Returns the string representation of the given data type.
    *
-   * @param componentDatatype The component datatype
+   * @param componentDatatype - The component datatype
    * @returns The string
    *
    * @throws DracoError when componentDatatype is not a valid value.

--- a/src/contentProcessing/draco/DracoDecoder.ts
+++ b/src/contentProcessing/draco/DracoDecoder.ts
@@ -57,7 +57,7 @@ export class DracoDecoder {
    *
    * @param properties - The mapping from property names (like
    * `POSITION`) to IDs
-   * @param binary The binary data to to decode from
+   * @param binary - The binary data to to decode from
    * @returns The decoded data for each attribute, and information
    * about its structure
    * @throws DracoError If the data could not be decoded

--- a/src/contentProcessing/pointClouds/DefaultPointCloud.ts
+++ b/src/contentProcessing/pointClouds/DefaultPointCloud.ts
@@ -75,8 +75,8 @@ export class DefaultPointCloud implements ReadablePointCloud {
    *
    * @param name - The name, e.g. `"POSITION"`
    * @param type - The type, e.g. `"VEC3"`
-   * @param componentType The component type, e.g. `"FLOAT32"`
-   * @param attribute The attribute values
+   * @param componentType - The component type, e.g. `"FLOAT32"`
+   * @param attribute - The attribute values
    */
   addAttribute(
     name: string,

--- a/src/contentProcessing/pointClouds/GltfTransformPointClouds.ts
+++ b/src/contentProcessing/pointClouds/GltfTransformPointClouds.ts
@@ -39,6 +39,8 @@ export interface GltfTransformPointCloud {
 
 /**
  * Methods to create glTF representations of point clouds
+ *
+ * @internal
  */
 export class GltfTransformPointClouds {
   /**

--- a/src/gltfExtensions/EXTInstanceFeatures.ts
+++ b/src/gltfExtensions/EXTInstanceFeatures.ts
@@ -35,7 +35,9 @@ type FeatureIdAttributeDef = number;
  *
  * Properties:
  * - {@link InstanceFeatures}
- * - {@link FeatureId}
+ * - {@link InstanceFeaturesFeatureId}
+ *
+ * @internal
  */
 export class EXTInstanceFeatures extends Extension {
   public override readonly extensionName = NAME;

--- a/src/gltfExtensions/EXTMeshFeatures.ts
+++ b/src/gltfExtensions/EXTMeshFeatures.ts
@@ -62,7 +62,7 @@ interface FeatureIdTextureDef extends GLTF.ITextureInfo {
  *
  * Properties:
  * - {@link MeshFeatures}
- * - {@link FeatureId}
+ * - {@link MeshFeaturesFeatureId}
  * - {@link FeatureIdTexture}
  *
  * ### Example
@@ -114,6 +114,8 @@ interface FeatureIdTextureDef extends GLTF.ITextureInfo {
  * // Write the document as JSON
  * const written = await io.writeJSON(document);
  * ```
+ *
+ * @internal
  */
 export class EXTMeshFeatures extends Extension {
   public override readonly extensionName = NAME;

--- a/src/gltfExtensions/EXTStructuralMetadata.ts
+++ b/src/gltfExtensions/EXTStructuralMetadata.ts
@@ -48,6 +48,8 @@ function ifNot<T>(value: T, defaultValue: T): T | undefined {
 
 /**
  * The type of a metadata class property
+ *
+ * @internal
  */
 export type ClassPropertyType =
   | "SCALAR"
@@ -63,6 +65,8 @@ export type ClassPropertyType =
 
 /**
  * The component type of a metadata class property
+ *
+ * @internal
  */
 export type ClassPropertyComponentType =
   | "INT8"
@@ -78,6 +82,8 @@ export type ClassPropertyComponentType =
 
 /**
  * The value type of a metadata enum
+ *
+ * @internal
  */
 export type EnumValueType =
   | "INT8"
@@ -91,6 +97,8 @@ export type EnumValueType =
 
 /**
  * The type of the string- or array offsets for a property table property
+ *
+ * @internal
  */
 export type PropertyTablePropertyOffsetType =
   | "UINT8"
@@ -226,6 +234,12 @@ interface MeshPrimitiveStructuralMetadataDef {
 
 //============================================================================
 
+/**
+ * [`EXT_structural_metadata`](https://github.com/CesiumGS/glTF/tree/proposal-EXT_structural_metadata/extensions/2.0/Vendor/EXT_structural_metadata/)
+ * defines a means of storing structured metadata within a glTF 2.0 asset.
+ *
+ * @internal
+ */
 export class EXTStructuralMetadata extends Extension {
   // Implementation note:
   //
@@ -811,7 +825,7 @@ export class EXTStructuralMetadata extends Extension {
    * that corresponds to the buffer view.
    *
    * @param context - The reader context
-   * @param bufferViewIndex The buffer view index
+   * @param bufferViewIndex - The buffer view index
    * @returns The buffer view data
    */
   private static obtainBufferViewData(

--- a/src/gltfExtensions/InstanceFeatures.ts
+++ b/src/gltfExtensions/InstanceFeatures.ts
@@ -28,6 +28,11 @@ type FeatureIdAttribute = number;
 // (See `MeshFeatures` for details about the concepts)
 //
 
+/**
+ * Main model class for `EXT_instance_features`
+ *
+ * @internal
+ */
 export class InstanceFeatures extends ExtensionProperty<IInstanceFeatures> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -57,6 +62,11 @@ export class InstanceFeatures extends ExtensionProperty<IInstanceFeatures> {
   }
 }
 
+/**
+ * Implementation of a feature ID for `EXT_instance_features`
+ *
+ * @internal
+ */
 export class FeatureId extends ExtensionProperty<IFeatureId> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;

--- a/src/gltfExtensions/MeshFeatures.ts
+++ b/src/gltfExtensions/MeshFeatures.ts
@@ -83,6 +83,11 @@ interface IFeatureIdTexture extends IProperty {
 // }
 // ```
 
+/**
+ * Main model class of `EXT_mesh_features`
+ *
+ * @internal
+ */
 export class MeshFeatures extends ExtensionProperty<IMeshFeatures> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -112,6 +117,11 @@ export class MeshFeatures extends ExtensionProperty<IMeshFeatures> {
   }
 }
 
+/**
+ * Implementation of a feature ID for `EXT_mesh_features`
+ *
+ * @internal
+ */
 export class FeatureId extends ExtensionProperty<IFeatureId> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -171,6 +181,11 @@ export class FeatureId extends ExtensionProperty<IFeatureId> {
   }
 }
 
+/**
+ * Implementation of a feature ID texture for `EXT_mesh_features`
+ *
+ * @internal
+ */
 export class FeatureIdTexture extends ExtensionProperty<IFeatureIdTexture> {
   static override EXTENSION_NAME = NAME;
 

--- a/src/gltfExtensions/StructuralMetadata.ts
+++ b/src/gltfExtensions/StructuralMetadata.ts
@@ -160,6 +160,11 @@ interface IMeshPrimitiveStructuralMetadata extends IProperty {
 // (See `MeshFeatures` for details about the concepts)
 //
 
+/**
+ * Main model class for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class StructuralMetadata extends ExtensionProperty<IStructuralMetadata> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -225,6 +230,11 @@ export class StructuralMetadata extends ExtensionProperty<IStructuralMetadata> {
   }
 }
 
+/**
+ * Implementation of a metadata schema for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class Schema extends ExtensionProperty<ISchema> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -299,6 +309,11 @@ export class Schema extends ExtensionProperty<ISchema> {
   }
 }
 
+/**
+ * Implementation of a metadata class for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class Class extends ExtensionProperty<IClass> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -345,6 +360,11 @@ export class Class extends ExtensionProperty<IClass> {
   }
 }
 
+/**
+ * Implementation of a metadata class property for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class ClassProperty extends ExtensionProperty<IClassProperty> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -471,6 +491,11 @@ export class ClassProperty extends ExtensionProperty<IClassProperty> {
   }
 }
 
+/**
+ * Implementation of a metadata enum for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class Enum extends ExtensionProperty<IEnum> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -522,6 +547,11 @@ export class Enum extends ExtensionProperty<IEnum> {
   }
 }
 
+/**
+ * Implementation of a metadata enum value for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class EnumValue extends ExtensionProperty<IEnumValue> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -560,6 +590,11 @@ export class EnumValue extends ExtensionProperty<IEnumValue> {
   }
 }
 
+/**
+ * Implementation of a property table for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class PropertyTable extends ExtensionProperty<IPropertyTable> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -613,6 +648,11 @@ export class PropertyTable extends ExtensionProperty<IPropertyTable> {
   }
 }
 
+/**
+ * Implementation of a property table property for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class PropertyTableProperty extends ExtensionProperty<IPropertyTableProperty> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -696,6 +736,11 @@ export class PropertyTableProperty extends ExtensionProperty<IPropertyTablePrope
   }
 }
 
+/**
+ * Implementation of a property texture for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class PropertyTexture extends ExtensionProperty<IPropertyTexture> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -742,6 +787,11 @@ export class PropertyTexture extends ExtensionProperty<IPropertyTexture> {
   }
 }
 
+/**
+ * Implementation of a property texture property for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class PropertyTextureProperty extends ExtensionProperty<IPropertyTextureProperty> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -812,6 +862,11 @@ export class PropertyTextureProperty extends ExtensionProperty<IPropertyTextureP
   }
 }
 
+/**
+ * Implementation of a property attribute for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class PropertyAttribute extends ExtensionProperty<IPropertyAttribute> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -858,6 +913,11 @@ export class PropertyAttribute extends ExtensionProperty<IPropertyAttribute> {
   }
 }
 
+/**
+ * Implementation of a property attribute property for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class PropertyAttributeProperty extends ExtensionProperty<IPropertyAttributeProperty> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -910,6 +970,11 @@ export class PropertyAttributeProperty extends ExtensionProperty<IPropertyAttrib
   }
 }
 
+/**
+ * Implementation of a metadata entity for `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class ElementStructuralMetadata extends ExtensionProperty<IElementStructuralMetadata> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;
@@ -941,6 +1006,11 @@ export class ElementStructuralMetadata extends ExtensionProperty<IElementStructu
   }
 }
 
+/**
+ * Implementation of a structural metadata in a mesh primitive `EXT_structural_metadata`
+ *
+ * @internal
+ */
 export class MeshPrimitiveStructuralMetadata extends ExtensionProperty<IMeshPrimitiveStructuralMetadata> {
   static override EXTENSION_NAME = NAME;
   public declare extensionName: typeof NAME;

--- a/src/implicitTiling/BufferAvailabilityInfo.ts
+++ b/src/implicitTiling/BufferAvailabilityInfo.ts
@@ -3,6 +3,8 @@ import { AvailabilityInfo } from "./AvailabilityInfo";
 /**
  * Implementation of an `AvailabilityInfo` that is backed by
  * a Buffer.
+ *
+ * @internal
  */
 export class BufferAvailabilityInfo implements AvailabilityInfo {
   private readonly _buffer: Buffer;

--- a/src/implicitTiling/ConstantAvailabilityInfo.ts
+++ b/src/implicitTiling/ConstantAvailabilityInfo.ts
@@ -2,6 +2,8 @@ import { AvailabilityInfo } from "./AvailabilityInfo";
 
 /**
  * Implementation of an `AvailabilityInfo` that has a constant value.
+ *
+ * @internal
  */
 export class ConstantAvailabilityInfo implements AvailabilityInfo {
   private readonly _available: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,170 @@
 export * from "./base/Buffers";
+export * from "./base/DataError";
 export * from "./base/defaultValue";
 export * from "./base/defined";
 export * from "./base/DeveloperError";
 export * from "./base/Iterables";
 export * from "./base/Paths";
 export * from "./base/Uris";
+
+export * from "./binary/BinaryBufferData";
+export * from "./binary/BinaryBufferDataResolver";
+export * from "./binary/BinaryBuffers";
+export * from "./binary/BinaryBufferStructure";
+export * from "./binary/BinaryDataError";
+
+export * from "./contentProcessing/ContentError";
+export * from "./contentProcessing/ContentOps";
+export * from "./contentProcessing/ContentUpgrades";
+export * from "./contentProcessing/GltfPack";
+export * from "./contentProcessing/GltfPackOptions";
+export * from "./contentProcessing/GltfPipelineLegacy";
+export * from "./contentProcessing/GltfTransform";
+export * from "./contentProcessing/GltfTransformTextures";
+export * from "./contentProcessing/GltfUtilities";
+export * from "./contentProcessing/draco/AttributeInfo";
+export * from "./contentProcessing/draco/ComponentDataType";
+export * from "./contentProcessing/draco/DracoDecoder";
+export * from "./contentProcessing/draco/DracoDecoderResult";
+export * from "./contentProcessing/draco/DracoError";
+export * from "./contentProcessing/draco/QuantizationInfo";
+export * from "./contentProcessing/pointClouds/DefaultPointCloud";
+export * from "./contentProcessing/pointClouds/GltfTransformPointClouds";
+export * from "./contentProcessing/pointClouds/PntsPointClouds";
+export * from "./contentProcessing/pointClouds/ReadablePointCloud";
+
+export * from "./contentTypes/BufferedContentData";
+export * from "./contentTypes/ContentData";
+export * from "./contentTypes/ContentDataTypeChecks";
+export * from "./contentTypes/ContentDataTypeEntry";
+export * from "./contentTypes/ContentDataTypeRegistry";
+export * from "./contentTypes/ContentDataTypes";
+export * from "./contentTypes/LazyContentData";
+
+export * from "./gltfExtensions/EXTInstanceFeatures";
+export * from "./gltfExtensions/EXTMeshFeatures";
+export * from "./gltfExtensions/EXTStructuralMetadata";
+
+export { InstanceFeatures } from "./gltfExtensions/InstanceFeatures";
+export { FeatureId as InstanceFeaturesFeatureId } from "./gltfExtensions/InstanceFeatures";
+export * from "./gltfExtensions/InstanceFeaturesUtils";
+
+export { MeshFeatures } from "./gltfExtensions/MeshFeatures";
+export { FeatureId as MeshFeaturesFeatureId } from "./gltfExtensions/MeshFeatures";
+export { FeatureIdTexture } from "./gltfExtensions/MeshFeatures";
+export * from "./gltfExtensions/MeshFeaturesUtils";
+
+export { StructuralMetadata } from "./gltfExtensions/StructuralMetadata";
+export { Schema as StructuralMetadataSchema } from "./gltfExtensions/StructuralMetadata";
+export { Class as StructuralMetadataClass } from "./gltfExtensions/StructuralMetadata";
+export { ClassProperty as StructuralMetadataClassProperty } from "./gltfExtensions/StructuralMetadata";
+export { Enum as StructuralMetadataEnum } from "./gltfExtensions/StructuralMetadata";
+export { EnumValue as StructuralMetadataEnumValue } from "./gltfExtensions/StructuralMetadata";
+export { PropertyTable as StructuralMetadataPropertyTable } from "./gltfExtensions/StructuralMetadata";
+export { PropertyTableProperty as StructuralMetadataPropertyTableProperty } from "./gltfExtensions/StructuralMetadata";
+export { PropertyTexture as StructuralMetadataPropertyTexture } from "./gltfExtensions/StructuralMetadata";
+export { PropertyTextureProperty as StructuralMetadataPropertyTextureProperty } from "./gltfExtensions/StructuralMetadata";
+export { PropertyAttribute as StructuralMetadataPropertyAttribute } from "./gltfExtensions/StructuralMetadata";
+export { PropertyAttributeProperty as StructuralMetadataPropertyAttributeProperty } from "./gltfExtensions/StructuralMetadata";
+export { ElementStructuralMetadata } from "./gltfExtensions/StructuralMetadata";
+export { MeshPrimitiveStructuralMetadata } from "./gltfExtensions/StructuralMetadata";
+
+export * from "./gltfExtensions/StructuralMetadataPropertyTables";
+export * from "./gltfExtensions/StructuralMetadataUtils";
+export * from "./gltfExtensions/StringBuilder";
+
+export * from "./implicitTiling/AvailabilityInfo";
+export * from "./implicitTiling/AvailabilityInfos";
+export * from "./implicitTiling/BinarySubtreeData";
+export * from "./implicitTiling/BinarySubtreeDataResolver";
+export * from "./implicitTiling/BufferAvailabilityInfo";
+export * from "./implicitTiling/ConstantAvailabilityInfo";
+export * from "./implicitTiling/ImplicitTilingError";
+export * from "./implicitTiling/ImplicitTilings";
+export * from "./implicitTiling/SubtreeInfo";
+export * from "./implicitTiling/SubtreeInfos";
+export * from "./implicitTiling/TemplateUris";
+
+export * from "./io/FileResourceResolver";
+export * from "./io/ResourceResolver";
+export * from "./io/ResourceResolvers";
+export * from "./io/TilesetSourceResourceResolver";
+export * from "./io/UnzippingResourceResolver";
+
+export * from "./ktx/BasisEncoder";
+export * from "./ktx/KtxError";
+export * from "./ktx/KtxEtc1sOptions";
+export * from "./ktx/KtxOptions";
+export * from "./ktx/KtxUastcOptions";
+export * from "./ktx/KtxUtility";
+
+export * from "./logging/Loggers";
+
+export * from "./metadata/ArrayValues";
+export * from "./metadata/ClassProperties";
+export * from "./metadata/DefaultMetadataEntityModel";
+export * from "./metadata/DefaultPropertyModel";
+export * from "./metadata/DefaultPropertyTableModel";
+export * from "./metadata/MetadataComponentTypes";
+export * from "./metadata/MetadataEntityModel";
+export * from "./metadata/MetadataEntityModels";
+export * from "./metadata/MetadataError";
+export * from "./metadata/MetadataTypes";
+export * from "./metadata/MetadataUtilities";
+export * from "./metadata/MetadataValues";
+export * from "./metadata/PropertyModel";
+export * from "./metadata/PropertyModels";
+export * from "./metadata/PropertyTableModel";
+export * from "./metadata/PropertyTableModels";
+export * from "./metadata/TableMetadataEntityModel";
+
+export * from "./metadata/binary/ArrayBuffers";
+export * from "./metadata/binary/BinaryEnumInfo";
+export * from "./metadata/binary/BinaryMetadata";
+export * from "./metadata/binary/BinaryPropertyModels";
+export * from "./metadata/binary/BinaryPropertyTable";
+export * from "./metadata/binary/BinaryPropertyTableBuilder";
+export * from "./metadata/binary/BinaryPropertyTableModel";
+export * from "./metadata/binary/BinaryPropertyTables";
+export * from "./metadata/binary/BooleanArrayPropertyModel";
+export * from "./metadata/binary/BooleanPropertyModel";
+export * from "./metadata/binary/NumericArrayPropertyModel";
+export * from "./metadata/binary/NumericBuffers";
+export * from "./metadata/binary/NumericPropertyModel";
+export * from "./metadata/binary/StringArrayPropertyModel";
+export * from "./metadata/binary/StringPropertyModel";
+
+export * from "./migration/AccessorCreation";
+export * from "./migration/BatchTableClassProperties";
+export * from "./migration/BatchTablePropertyTableModels";
+export * from "./migration/BatchTableSchemas";
+export * from "./migration/Ids";
+export * from "./migration/NumberTypeDescriptions";
+export * from "./migration/TileFormatsMigration";
+export * from "./migration/TileFormatsMigrationB3dm";
+export * from "./migration/TileFormatsMigrationI3dm";
+export * from "./migration/TileFormatsMigrationPnts";
+export * from "./migration/TileTableDataToMeshFeatures";
+export * from "./migration/TileTableDataToStructuralMetadata";
+export * from "./migration/TypeDetection";
+
+export * from "./packages/ArchiveFunctions3tz";
+export * from "./packages/IndexBuilder";
+export * from "./packages/IndexBuilderEntry";
+export * from "./packages/IndexEntry";
+export * from "./packages/TableStructureValidator";
+export * from "./packages/TilesetSource3dtiles";
+export * from "./packages/TilesetSource3tz";
+export * from "./packages/TilesetTarget3dtiles";
+export * from "./packages/TilesetTarget3tz";
+export * from "./packages/ZipToPackage";
+
+export * from "./spatial/MortonOrder";
+export * from "./spatial/OctreeCoordinates";
+export * from "./spatial/Octrees";
+export * from "./spatial/QuadtreeCoordinates";
+export * from "./spatial/Quadtrees";
+export * from "./spatial/TreeCoordinates";
 
 export * from "./structure/Asset";
 export * from "./structure/Availability";
@@ -26,14 +186,36 @@ export * from "./structure/Subtrees";
 export * from "./structure/Tile";
 export * from "./structure/TileImplicitTiling";
 export * from "./structure/Tileset";
+
+export * from "./structure/extensions/BoundingVolumeS2";
+
 export * from "./structure/Metadata/ClassProperty";
 export * from "./structure/Metadata/EnumValue";
 export * from "./structure/Metadata/MetadataClass";
 export * from "./structure/Metadata/MetadataEnum";
 export * from "./structure/Metadata/Schema";
 
+export * from "./structure/Style/Style";
+
+export * from "./structure/TileFormats/B3dmFeatureTable";
+export * from "./structure/TileFormats/BatchTable";
+export * from "./structure/TileFormats/BatchTableBinaryBodyReference";
+export * from "./structure/TileFormats/BinaryBodyOffset";
+export * from "./structure/TileFormats/FeatureTable";
+export * from "./structure/TileFormats/FeatureTableBinaryBodyReference";
+export * from "./structure/TileFormats/I3dmFeatureTable";
+export * from "./structure/TileFormats/PntsFeatureTable";
+
+export * from "./tileFormats/CompositeTileData";
+export * from "./tileFormats/Header";
+export * from "./tileFormats/Table";
+export * from "./tileFormats/TileData";
+export * from "./tileFormats/TileDataLayouts";
+export * from "./tileFormats/TileFormatError";
+export * from "./tileFormats/TileFormats";
 export * from "./tilesetData/TilesetEntry";
 export * from "./tilesetData/TilesetError";
+export * from "./tilesetData/TilesetInMemory";
 export * from "./tilesetData/TilesetSource";
 export * from "./tilesetData/TilesetSourceFs";
 export * from "./tilesetData/TilesetSources";
@@ -41,86 +223,53 @@ export * from "./tilesetData/TilesetTarget";
 export * from "./tilesetData/TilesetTargetFs";
 export * from "./tilesetData/TilesetTargets";
 
-export * from "./packages/TilesetSource3dtiles";
-export * from "./packages/TilesetSource3tz";
-export * from "./packages/TilesetTarget3dtiles";
-export * from "./packages/TilesetTarget3tz";
+export * from "./tilesetProcessing/BasicTilesetProcessor";
+export * from "./tilesetProcessing/BoundingVolumes";
+export * from "./tilesetProcessing/TileContentProcessing";
+export * from "./tilesetProcessing/TileContentProcessor";
+export * from "./tilesetProcessing/TileContentProcessors";
+export * from "./tilesetProcessing/TileContentProcessorsGltfpack";
+export * from "./tilesetProcessing/TileContentProcessorsGltfPipeline";
+export * from "./tilesetProcessing/TileContentProcessorsGltfTransform";
+export * from "./tilesetProcessing/TileContentProcessorsTextures";
+export * from "./tilesetProcessing/TilesetCombiner";
+export * from "./tilesetProcessing/TilesetConverter";
+export * from "./tilesetProcessing/TilesetDataProcessor";
+export * from "./tilesetProcessing/TilesetEntryProcessor";
+export * from "./tilesetProcessing/TilesetJsonCreator";
+export * from "./tilesetProcessing/TilesetMerger";
+export * from "./tilesetProcessing/TilesetProcessing";
+export * from "./tilesetProcessing/TilesetProcessor";
+export * from "./tilesetProcessing/TilesetProcessorContext";
+export * from "./tilesetProcessing/TilesetProcessorContexts";
+export * from "./tilesetProcessing/TilesetUpgrader";
 
-// These should not be public, but are required for the
-// archive validation functions:
-// ---
-export * from "./packages/ArchiveFunctions3tz";
-export * from "./packages/IndexBuilder";
-export * from "./packages/IndexBuilderEntry";
-export * from "./packages/IndexEntry";
-// ---
+export * from "./tilesetProcessing/upgrade/TilesetObjectUpgrader";
+export * from "./tilesetProcessing/upgrade/TilesetUpgradeOptions";
 
-export * from "./io/FileResourceResolver";
-export * from "./io/ResourceResolver";
-export * from "./io/ResourceResolvers";
-export * from "./io/TilesetSourceResourceResolver";
-export * from "./io/UnzippingResourceResolver";
+export * from "./tilesets/Contents";
+export * from "./tilesets/Extensions";
+export * from "./tilesets/Tiles";
+export * from "./tilesets/Tilesets";
+export * from "./tilesets/TileTraversalCallback";
 
-export * from "./contentTypes/ContentData";
-export * from "./contentTypes/ContentDataTypeRegistry";
-export * from "./contentTypes/LazyContentData";
-
-export * from "./binary/BinaryBufferData";
-export * from "./binary/BinaryBufferDataResolver";
-export * from "./binary/BinaryBuffers";
-export * from "./binary/BinaryBufferStructure";
-export * from "./binary/BinaryDataError";
-
-export * from "./implicitTiling/AvailabilityInfo";
-export * from "./implicitTiling/AvailabilityInfos";
-export * from "./implicitTiling/BinarySubtreeData";
-export * from "./implicitTiling/BinarySubtreeDataResolver";
-export * from "./implicitTiling/ImplicitTilingError";
-export * from "./implicitTiling/ImplicitTilings";
-export * from "./implicitTiling/SubtreeInfo";
-export * from "./implicitTiling/SubtreeInfos";
-export * from "./implicitTiling/TemplateUris";
-
-export * from "./spatial/OctreeCoordinates";
-export * from "./spatial/Octrees";
-export * from "./spatial/QuadtreeCoordinates";
-export * from "./spatial/Quadtrees";
-export * from "./spatial/TreeCoordinates";
-
-export * from "./metadata/ArrayValues";
-export * from "./metadata/ClassProperties";
-export * from "./metadata/DefaultMetadataEntityModel";
-export * from "./metadata/MetadataComponentTypes";
-export * from "./metadata/MetadataUtilities";
-export * from "./metadata/MetadataEntityModel";
-export * from "./metadata/MetadataEntityModels";
-export * from "./metadata/MetadataError";
-export * from "./metadata/MetadataTypes";
-export * from "./metadata/MetadataUtilities";
-export * from "./metadata/MetadataValues";
-export * from "./metadata/PropertyModel";
-export * from "./metadata/PropertyTableModel";
-
-export * from "./metadata/binary/BinaryPropertyTable";
-export * from "./metadata/binary/BinaryMetadata";
-export * from "./metadata/binary/BinaryPropertyTables";
-export * from "./metadata/binary/BinaryPropertyTableModel";
-export * from "./metadata/binary/BinaryPropertyModels";
-export * from "./metadata/binary/BinaryEnumInfo";
-export * from "./metadata/binary/NumericBuffers";
+export * from "./tileTableData/AttributeCompression";
+export * from "./tileTableData/BatchTables";
+export * from "./tileTableData/Colors";
+export * from "./tileTableData/TileTableData";
+export * from "./tileTableData/TileTableDataI3dm";
+export * from "./tileTableData/TileTableDataPnts";
+export * from "./tileTableData/VecMath";
 
 export * from "./traversal/ExplicitTraversedTile";
 export * from "./traversal/ExplicitTraversedTiles";
 export * from "./traversal/ImplicitTraversedTile";
+export * from "./traversal/MetadataSemanticOverrides";
 export * from "./traversal/SubtreeMetadataModel";
 export * from "./traversal/SubtreeMetadataModels";
 export * from "./traversal/SubtreeModel";
 export * from "./traversal/SubtreeModels";
 export * from "./traversal/TilesetTraverser";
-export * from "./traversal/TraversedTile";
+export * from "./traversal/TilesetTraversers";
 export * from "./traversal/TraversalCallback";
-
-// For glTF extension validation experiments
-
-export * from "./contentProcessing/GltfUtilities";
-export * from "./contentProcessing/GltfTransform";
+export * from "./traversal/TraversedTile";

--- a/src/ktx/BasisEncoder.ts
+++ b/src/ktx/BasisEncoder.ts
@@ -12,6 +12,8 @@ import { DeveloperError } from "../base/DeveloperError";
  * You create this object, call the set() methods to fill in the parameters/source images/options, call encode(), and you get back a .basis or .KTX2 file.
  * You can call .encode() multiple times, changing the parameters/options in between calls.
  * By default this class encodes to .basis, but call setCreateKTX2File() with true to get .KTX2 files.
+ *
+ * @internal
  */
 export class BasisEncoder {
   /**
@@ -323,7 +325,7 @@ export class BasisEncoder {
 
   /**
    * Sets the mipmap filter to apply
-   * mip_filter must be < BASISU_MAX_RESAMPLER_FILTERS
+   * mip_filter must be less than BASISU_MAX_RESAMPLER_FILTERS
    * See the end of basisu_resample_filters.cpp: g_resample_filters[]
    *
    * @param mip_filter - The value

--- a/src/ktx/KtxEtc1sOptions.ts
+++ b/src/ktx/KtxEtc1sOptions.ts
@@ -1,5 +1,7 @@
 /**
  * A set of options for configuring KTX ETC1S compression in the `KtxUtility`
+ *
+ * @internal
  */
 export type KtxEtc1sOptions = Partial<{
   /**

--- a/src/ktx/KtxOptions.ts
+++ b/src/ktx/KtxOptions.ts
@@ -3,6 +3,8 @@ import { KtxUastcOptions } from "./KtxUastcOptions";
 
 /**
  * A set of options for configuring KTX compression in the `KtxUtility`
+ *
+ * @internal
  */
 export type KtxOptions = KtxEtc1sOptions &
   KtxUastcOptions & {

--- a/src/ktx/KtxUastcOptions.ts
+++ b/src/ktx/KtxUastcOptions.ts
@@ -1,5 +1,7 @@
 /**
  * A set of options for configuring KTX UASTC compression in the `KtxUtility`
+ *
+ * @internal
  */
 export type KtxUastcOptions = Partial<{
   /**

--- a/src/ktx/KtxUtility.ts
+++ b/src/ktx/KtxUtility.ts
@@ -13,6 +13,8 @@ const logger = Loggers.get("KTX");
 
 /**
  * Utility class for converting images into KTX2 format.
+ *
+ * @internal
  */
 export class KtxUtility {
   /**
@@ -24,7 +26,7 @@ export class KtxUtility {
    *
    * @param inputFileName - The input file name
    * @param outputFileName - The output file name
-   * @param options The options for the KTX compression
+   * @param options - The options for the KTX compression
    * @throws KtxError If the input data could not be read or
    * encoded to KTX
    */
@@ -53,7 +55,7 @@ export class KtxUtility {
    * specified, but they include JPG and PNG.
    *
    * @param inputImageData - The input file name
-   * @param options The options for the KTX compression
+   * @param options - The options for the KTX compression
    * @returns The KTX compressed data
    * @throws KtxError If the input data could not be read or
    * encoded to KTX
@@ -87,10 +89,10 @@ export class KtxUtility {
    * Encode the given RGBA pixels with KTX, and reuturn the
    * result as a buffer.
    *
-   * @param imageWidth The image width
-   * @param imageHeight The image height
-   * @param rgbaPixels The pixels
-   * @param options The options for the KTX compression
+   * @param imageWidth - The image width
+   * @param imageHeight - The image height
+   * @param rgbaPixels - The pixels
+   * @param options - The options for the KTX compression
    * @returns The KTX data
    * @throws KtxError If the input data could not be
    * encoded to KTX

--- a/src/ktx/KtxUtility.ts
+++ b/src/ktx/KtxUtility.ts
@@ -139,6 +139,7 @@ export class KtxUtility {
     }
 
     const resultSize = basisEncoder.encode(basisData);
+    basisEncoder.delete();
     if (resultSize === 0) {
       throw new KtxError("Could not encode image data to KTX");
     }

--- a/src/logging/Loggers.ts
+++ b/src/logging/Loggers.ts
@@ -3,6 +3,11 @@ import { TransportTargetOptions } from "pino";
 import { Logger } from "pino";
 import { LoggerOptions } from "pino";
 
+/**
+ * Methods for creating and maintaining logger instances.
+ *
+ * @internal
+ */
 export class Loggers {
   /**
    * A mapping from names to logger instances

--- a/src/metadata/PropertyTableModels.ts
+++ b/src/metadata/PropertyTableModels.ts
@@ -72,8 +72,8 @@ export class PropertyTableModels {
    * representation of any value in the respective column)
    *
    * @param propertyTableModel - The `PropertyTableModel`
-   * @param propertyNames The property names
-   * @param rows The number of rows
+   * @param propertyNames - The property names
+   * @param rows - The number of rows
    * @returns The column widths
    */
   private static computeColumnWidths(

--- a/src/migration/TileFormatsMigrationPnts.ts
+++ b/src/migration/TileFormatsMigrationPnts.ts
@@ -167,7 +167,7 @@ export class TileFormatsMigrationPnts {
    * attributes in the `EXT_structural_metadata` extension.
    *
    * @param pntsPointCloud - The point cloud that contains the PNTS data
-   * @param batchTable The batch table
+   * @param batchTable - The batch table
    * @returns The mapping
    */
   private static computeExternalProperties(

--- a/src/packages/ZipToPackage.ts
+++ b/src/packages/ZipToPackage.ts
@@ -20,13 +20,13 @@ export class ZipToPackage {
    * If it is `.3dtiles`, then the output will be a 3DTILES package
    * If it is empty, then the output will be a directory
    *
-   * @param inputFileName The full input file name
-   * @param inputTilesetJsonFileName The name of the tileset JSON file that
+   * @param inputFileName - The full input file name
+   * @param inputTilesetJsonFileName - The name of the tileset JSON file that
    * is expected to be present in the ZIP. This will usually be
    * 'tileset.json', but can be overridden to use another JSON file as
    * the main tileset JSON file.
-   * @param outputFileName The full output file name
-   * @param overwrite Whether the output file should be overwritten
+   * @param outputFileName - The full output file name
+   * @param overwrite - Whether the output file should be overwritten
    * if it already exists
    * @throws TilesetError If the input did not contain the tileset JSON
    * file that was expected for the input or the output.

--- a/src/pipelines/TilesetStageExecutor.ts
+++ b/src/pipelines/TilesetStageExecutor.ts
@@ -231,8 +231,7 @@ export class TilesetStageExecutor {
     overwrite: boolean
   ) {
     try {
-      const quiet = false;
-      const tilesetProcessor = new BasicTilesetProcessor(quiet);
+      const tilesetProcessor = new BasicTilesetProcessor();
       await tilesetProcessor.begin(currentInput, currentOutput, overwrite);
 
       const contentStages = tilesetStage.contentStages;

--- a/src/tileFormats/TileDataLayouts.ts
+++ b/src/tileFormats/TileDataLayouts.ts
@@ -45,6 +45,8 @@ export interface TileDataLayout {
 /**
  * Methods to compute `TileDataLayout` instances from the information
  * that was read from the binary header.
+ *
+ * @internal
  */
 export class TileDataLayouts {
   static create(buffer: Buffer): TileDataLayout {

--- a/src/tileFormats/TileFormats.ts
+++ b/src/tileFormats/TileFormats.ts
@@ -129,7 +129,7 @@ export class TileFormats {
    *
    * @param buffer - The buffer
    * @param tileDataLayout - The tile data layout
-   * @return The `TileData`
+   * @returns The `TileData`
    * @internal
    */
   static extractTileData(buffer: Buffer, tileDataLayout: TileDataLayout) {
@@ -225,7 +225,7 @@ export class TileFormats {
    * Implementation for `extractGlbBuffers`, called recursively.
    *
    * @param tileDataBuffer - The tile data buffer
-   * @param glbBuffers The array of GLB buffers
+   * @param glbBuffers - The array of GLB buffers
    */
   private static extractGlbBuffersInternal(
     tileDataBuffer: Buffer,

--- a/src/tileTableData/TileTableDataI3dm.ts
+++ b/src/tileTableData/TileTableDataI3dm.ts
@@ -22,8 +22,8 @@ export class TileTableDataI3dm {
    * from the given I3DM feature table data.
    *
    * @param featureTable - The feature table
-   * @param featureTableBinary The feature table binary
-   * @param numInstances The number of instances
+   * @param featureTableBinary - The feature table binary
+   * @param numInstances - The number of instances
    * @returns The matrices as an iterable over 16-element arrays
    */
   static createInstanceMatrices(
@@ -73,7 +73,7 @@ export class TileTableDataI3dm {
    * @param translations3D - The translations as 3-element arrays
    * @param rotationQuaternions - The rotations as 4-element arrays
    * @param scales3D - The scaling factors as 3-element arrays
-   * @param numInstances The number of elements
+   * @param numInstances - The number of elements
    * @returns The matrices
    */
   static createMatrices(
@@ -117,8 +117,8 @@ export class TileTableDataI3dm {
    * feature table).
    *
    * @param featureTable - The feature table
-   * @param featureTableBinary The feature table binary
-   * @param numInstances The number of instances
+   * @param featureTableBinary - The feature table binary
+   * @param numInstances - The number of instances
    * @returns The positions as an iterable over 3-element arrays
    */
   static createWorldPositions(
@@ -167,8 +167,8 @@ export class TileTableDataI3dm {
    * returned.
    *
    * @param featureTable - The feature table
-   * @param featureTableBinary The feature table binary
-   * @param numInstances The number of instances
+   * @param featureTableBinary - The feature table binary
+   * @param numInstances - The number of instances
    * @returns The rotation quaternions as an iterable over 4-element arrays
    */
   static createRotationQuaternions(

--- a/src/tileTableData/VecMath.ts
+++ b/src/tileTableData/VecMath.ts
@@ -56,8 +56,8 @@ export class VecMath {
    * The vectors are given as 3-element arrays. The resulting
    * quaternions will be 4-element arrays.
    *
-   * @param upVectors The up-vectors
-   * @param rightVectors The right-vectors
+   * @param upVectors - The up-vectors
+   * @param rightVectors - The right-vectors
    * @returns The rotation quaternions
    */
   static computeRotationQuaternions(

--- a/src/tilesetProcessing/BasicTilesetProcessor.ts
+++ b/src/tilesetProcessing/BasicTilesetProcessor.ts
@@ -158,7 +158,7 @@ export class BasicTilesetProcessor extends TilesetProcessor {
    * The given tile is assumed to be an explicit tile in the
    * current tileset.
    *
-   * @param tile The tile where to start the traversal
+   * @param tile - The tile where to start the traversal
    * @param callback - The callback
    * @returns A promise that resolves when the process is finished
    * @throws DeveloperError If `begin` was not called yet

--- a/src/tilesetProcessing/BoundingVolumes.ts
+++ b/src/tilesetProcessing/BoundingVolumes.ts
@@ -53,8 +53,8 @@ export class BoundingVolumes {
   /**
    * Creates a boundingVolume.box from a given bounding box
    *
-   * @param boundingBox The bounding box
-   * @return The `boundingVolume.box`
+   * @param boundingBox - The bounding box
+   * @returns The `boundingVolume.box`
    */
   static createBoundingVolumeBoxFromBoundingBox(
     boundingBox: BoundingBox3D
@@ -98,13 +98,13 @@ export class BoundingVolumes {
    * https://github.com/CesiumGS/3d-tiles/tree/main/specification#box,
    * computed from the minimum- and maximum point of a box.
    *
-   * @param minX The minimum x
-   * @param minY The minimum y
-   * @param minZ The minimum z
-   * @param maxX The maximum x
-   * @param maxY The maximum y
-   * @param maxZ The maximum z
-   * @return The `boundingVolume.box`
+   * @param minX - The minimum x
+   * @param minY - The minimum y
+   * @param minZ - The minimum z
+   * @param maxX - The maximum x
+   * @param maxY - The maximum y
+   * @param maxZ - The maximum z
+   * @returns The `boundingVolume.box`
    */
   private static createBoundingVolumeBox(
     minX: number,
@@ -150,8 +150,8 @@ export class BoundingVolumes {
    * the given bounding box will be transformed with the
    * y-up-to-z-up transform.
    *
-   * @param boundingBox The bounding box
-   * @return The `boundingVolume.box`
+   * @param boundingBox - The bounding box
+   * @returns The `boundingVolume.box`
    */
   static createBoundingVolumeBoxFromGltfBoundingBox(
     boundingBox: BoundingBox3D
@@ -171,7 +171,7 @@ export class BoundingVolumes {
    * Create the BoundingBox3D for the given boundingVolume.box
    *
    * @param boundingVolumeBox - The bounding volume box
-   * @return The bounding box
+   * @returns The bounding box
    */
   static createBoundingBoxForBoundingVolumeBox(
     boundingVolumeBox: number[]

--- a/src/tilesetProcessing/TileContentProcessing.ts
+++ b/src/tilesetProcessing/TileContentProcessing.ts
@@ -23,8 +23,8 @@ export class TileContentProcessing {
    *
    * @param tilesetSourceName - The name of the `TilesetSource`
    * @param tilesetTargetName - The name of the `TilesetTarget`
-   * @param overwrite Whether existing output may be overwritten
-   * @param tileContentProcessor The `TileContentProcessor`
+   * @param overwrite - Whether existing output may be overwritten
+   * @param tileContentProcessor - The `TileContentProcessor`
    * @returns A promise that resolves when the process is finished
    */
   static async process(

--- a/src/tilesetProcessing/TileContentProcessing.ts
+++ b/src/tilesetProcessing/TileContentProcessing.ts
@@ -33,8 +33,7 @@ export class TileContentProcessing {
     overwrite: boolean,
     tileContentProcessor: TileContentProcessor
   ): Promise<void> {
-    const quiet = false;
-    const tilesetProcessor = new BasicTilesetProcessor(quiet);
+    const tilesetProcessor = new BasicTilesetProcessor();
     await tilesetProcessor.begin(
       tilesetSourceName,
       tilesetTargetName,

--- a/src/tilesetProcessing/TilesetCombiner.ts
+++ b/src/tilesetProcessing/TilesetCombiner.ts
@@ -69,7 +69,7 @@ export class TilesetCombiner {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed,
@@ -116,11 +116,11 @@ export class TilesetCombiner {
    * The caller is responsible for opening and closing the given
    * source and target.
    *
-   * @param tilesetSource The tileset source
-   * @param tilesetSourceJsonFileName The name of the top-level tileset in
+   * @param tilesetSource - The tileset source
+   * @param tilesetSourceJsonFileName - The name of the top-level tileset in
    * the given source (usually `tileset.json`).
-   * @param tilesetTarget The tileset target
-   * @param tilesetTargetJsonFileName The name of the top-level tileset in
+   * @param tilesetTarget - The tileset target
+   * @param tilesetTargetJsonFileName - The name of the top-level tileset in
    * the given target (usually `tileset.json`).
    * @returns A promise that resolves when the process is finished.
    * @throws TilesetError When the input tileset file can not be

--- a/src/tilesetProcessing/TilesetConverter.ts
+++ b/src/tilesetProcessing/TilesetConverter.ts
@@ -36,7 +36,7 @@ export class TilesetConverter {
    * contains a file that matches the required file for the output.
    *
    * @param input - The full input name
-   * @param inputTilesetJsonFileName The name of the tileset JSON file
+   * @param inputTilesetJsonFileName - The name of the tileset JSON file
    * in the input. When this is not given, then the name will either be
    * the file name of the input (if the input was a JSON file), or default
    * to 'tileset.json' (if the input was a directory or a tileset package)

--- a/src/tilesetProcessing/TilesetJsonCreator.ts
+++ b/src/tilesetProcessing/TilesetJsonCreator.ts
@@ -60,7 +60,7 @@ export class TilesetJsonCreator {
    *
    * @param baseDir - The base directory against which the
    * content URIs are resolved
-   * @param contentUris The content URIs
+   * @param contentUris - The content URIs
    * @returns The tileset
    * @throws Error if content data could not be read
    */
@@ -99,7 +99,7 @@ export class TilesetJsonCreator {
    *
    * @param baseDir - The base directory against which the
    * content URI is resolved
-   * @param contentUri The content URI
+   * @param contentUri - The content URI
    * @returns The leaf tile
    * @throws Error if content data could not be read
    */
@@ -150,8 +150,8 @@ export class TilesetJsonCreator {
    * Computes the bounding box from the given content data.
    *
    * @param contentUri - The content URI
-   * @param data The content data
-   * @param externalGlbResolver The resolver for external GLBs in I3DMs
+   * @param data - The content data
+   * @param externalGlbResolver - The resolver for external GLBs in I3DMs
    * @returns The bounding box, or undefined if no bounding box could
    * be computed from the given content.
    * @throws Error if the I3DM referred to a GLB that could not be

--- a/src/tilesetProcessing/TilesetProcessor.ts
+++ b/src/tilesetProcessing/TilesetProcessor.ts
@@ -53,7 +53,7 @@ export abstract class TilesetProcessor {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @returns A promise that resolves when this processor has been
    * initialized
@@ -195,7 +195,7 @@ export abstract class TilesetProcessor {
    * the result.
    *
    * @param sourceEntry - The source entry
-   * @param entryProcessor The `TilesetEntryProcessor`
+   * @param entryProcessor - The `TilesetEntryProcessor`
    * @returns The target entry
    */
   private async processEntryInternal(

--- a/src/tilesetProcessing/TilesetProcessorContexts.ts
+++ b/src/tilesetProcessing/TilesetProcessorContexts.ts
@@ -28,7 +28,7 @@ export class TilesetProcessorContexts {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @returns A promise that resolves when this processor has been
    * initialized
@@ -110,7 +110,7 @@ export class TilesetProcessorContexts {
    * Close the source and the target that are contained in the given
    * context.
    *
-   * @param context The context
+   * @param context - The context
    * @throws TilesetError If closing caused an error
    */
   static async close(context: TilesetProcessorContext) {

--- a/src/tilesetProcessing/TilesetUpgrader.ts
+++ b/src/tilesetProcessing/TilesetUpgrader.ts
@@ -118,7 +118,7 @@ export class TilesetUpgrader {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed,
@@ -156,7 +156,7 @@ export class TilesetUpgrader {
   /**
    * Perform the upgrade of the `Tileset` object, in place.
    *
-   * @param tileset The `Tileset` object
+   * @param tileset - The `Tileset` object
    */
   async upgradeTileset(tileset: Tileset) {
     const tilesetObjectUpgrader = new TilesetObjectUpgrader(
@@ -223,7 +223,7 @@ export class TilesetUpgrader {
    * Process the given tileset (content) entry, and return the result.
    *
    * @param sourceEntry - The source entry
-   * @param type The `ContentDataType` of the source entry
+   * @param type - The `ContentDataType` of the source entry
    * @returns The processed entry
    */
   private processEntry = async (
@@ -255,7 +255,7 @@ export class TilesetUpgrader {
    * Process the given tileset (content) entry, and return the result.
    *
    * @param sourceEntry - The source entry
-   * @param type The `ContentDataType` of the source entry
+   * @param type - The `ContentDataType` of the source entry
    * @returns The processed entry
    */
   private processEntryUnchecked = async (

--- a/src/tilesets/Contents.ts
+++ b/src/tilesets/Contents.ts
@@ -17,7 +17,7 @@ export class Contents {
    * This should never return `undefined`, but may be due to
    * invalid input data.
    *
-   * @param content The `Content`
+   * @param content - The `Content`
    * @returns The URI, or `undefined`
    */
   static getUri(content: Content): string | undefined {

--- a/src/tilesets/Extensions.ts
+++ b/src/tilesets/Extensions.ts
@@ -21,7 +21,7 @@ export class Extensions {
    * that is the given extension name.
    *
    * @param extended - The object that may contain the extension
-   * @param extension The extension (i.e. its name as a string)
+   * @param extension - The extension (i.e. its name as a string)
    * @returns Whether the object contains the extension
    */
   static containsExtension(extended: Extended, extension: string) {
@@ -37,7 +37,7 @@ export class Extensions {
    * empty.
    *
    * @param extended - The extended object
-   * @param extension The extension (i.e. its name as a string)
+   * @param extension - The extension (i.e. its name as a string)
    */
   static removeExtension(extended: Extended, extension: string) {
     if (!extended.extensions) {

--- a/src/tilesets/Tilesets.ts
+++ b/src/tilesets/Tilesets.ts
@@ -23,7 +23,7 @@ export class Tilesets {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed,
@@ -50,7 +50,7 @@ export class Tilesets {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed,
@@ -70,7 +70,7 @@ export class Tilesets {
    *
    * @param tilesetSourceName - The tileset source name
    * @param tilesetTargetName - The tileset target name
-   * @param overwrite Whether the target should be overwritten if
+   * @param overwrite - Whether the target should be overwritten if
    * it already exists
    * @param targetVersion - The target version - 1.0 or 1.1
    * @param gltfUpgradeOptions - Options that may be passed


### PR DESCRIPTION
The `index.ts` currently exports _most_ of the classes of the 3D Tiles tools.

(Even though **all** classes are considered to be `@internal` for now. The tools are only available as a command-line application, with no public API. Eventually, the tools should be split into multiple packages, each with a sensible public API. This process has already been started in https://github.com/CesiumGS/3d-tiles-tools/pull/64 , but there is no fixed timeline (yet) for this conversion. In the meantime, the tools should export _everything_, for internal experiments (which also serve the purpose of fleshing out _what_ actually should be exported as a public API, eventually)).

This PR updates the `index.ts` to export all classes (except for the `pipeline` classes).  

In addition to the usual maintenance steps (update of the auto-generated API file and `ThirdParty.json`), this PR affects many files in the `TSDoc updates` commit. But this commit does **not** affect anything except for the TSDoc. It only adds missing TSDocs, hyphens in `@param example - There must be that hyphen` declarations, and missing `@internal` tags for classes.
