### PR TITLE
Do not declare package as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "3d-tiles-tools",
   "version": "0.4.0",
   "license": "Apache-2.0",


### PR DESCRIPTION
A hotfix for the 0.4.0 release: There was a `private: true` setting in the package JSON that prevented publishing it.
