### PR TITLE
Extend and document `createTilesetJson`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 0.4.2 - yyyy-mm-dd
+
+- The `createTilesetJson` command has been extended to receive an optional cartographic position, which serves as the position of generated tileset.
+
+
 ### 0.4.1 - 2024-02-20
 
 - The packages that have been introduced in version `0.4.0` have been merged back into a single package.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,26 @@ npx 3d-tiles-tools analyze -i ./specs/data/batchedWithBatchTableBinary.b3dm -o .
 This will accept B3DM, I3DM, PNTS, CMPT, and GLB files (both for glTF 1.0 and for glTF 2.0), and write files into the output directory that contain the feature table, batch table, layout information, the GLB, and the JSON of the GLB. This is primarily intended for debugging and analyzing tile data. Therefore, the exact naming and content of the generated output files are not specified.
 
 
+#### createTilesetJson
+
+Create a tileset JSON file from a given set of tile content files.
+
+Additional command line options:
+
+| Flag | Description | Required |
+| ---- | ----------- | -------- |
+|`--cartographicPositionDegrees`|An array of either two or three values, which are the (longitude, latitude) or (longitude, latitude, height) of the target position. The longitude and latitude are given in degrees, and the height is given in meters.| No |
+
+If the input is a single file, then this will result in a single (root) tile with the input file as its tile content. If the input is a directory, then all content files in this directory will be used as tile content, recursively. The exact set of file types that are considered to be 'tile content' is not specified, but it will include GLB, B3DM, PNTS, I3DM, and CMPT files.
+
+Examples:
+
+```
+npx 3d-tiles-tools createTilesetJson -i ./input/ -o ./output/tileset.json --cartographicPositionDegrees -75.152 39.94 10
+```
+This creates the specified tileset JSON file, which will refer to all tile content files in the given input directory as its tile contents. The root node of the tileset will have a transform that will place it at the given cartographic position.
+
+
 
 ### Pipeline 
 

--- a/src/cli/ToolsMain.ts
+++ b/src/cli/ToolsMain.ts
@@ -567,6 +567,7 @@ export class ToolsMain {
   static async createTilesetJson(
     inputName: string,
     output: string,
+    cartographicPositionDegrees: number[] | undefined,
     force: boolean
   ) {
     logger.debug(`Executing createTilesetJson`);
@@ -588,11 +589,24 @@ export class ToolsMain {
         Paths.relativize(inputName, fileName)
       );
     }
-    logger.info(`Creating tileset.json with content URIs: ${contentUris}`);
+    logger.info(`Creating tileset JSON with content URIs: ${contentUris}`);
     const tileset = await TilesetJsonCreator.createTilesetFromContents(
       baseDir,
       contentUris
     );
+
+    if (cartographicPositionDegrees !== undefined) {
+      logger.info(
+        `Creating tileset at cartographic position: ` +
+          `${cartographicPositionDegrees} (in degress)`
+      );
+      const transform =
+        TilesetJsonCreator.computeTransformFromCartographicPositionDegrees(
+          cartographicPositionDegrees
+        );
+      tileset.root.transform = transform;
+    }
+
     const tilesetJsonString = JSON.stringify(tileset, null, 2);
     const outputDirectory = path.dirname(output);
     Paths.ensureDirectoryExists(outputDirectory);


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-tools/issues/104

The `createTilesetJson` function was not documented in the main README.md. This is now added here.

Additionally, the command is extended to receive a position for the generated tileset. The position is passed as `cartographicPositionDegrees` to the command, which can be a 2- or 3-element array that contains the `longitudeDeg, latitudeDeg, <heightMeters>` that should be used for the root transform of the generated tileset. For example:
```
npx ts-node ./src/cli/main.ts createTilesetJson -i ./temp/ -o ./temp/tileset.json --cartographicPositionDegrees 
-75.152 39.94 123.0
```

I hesitated a bit with the exact format. Passing around an `number[]` array feels a bit awkward, because you never know its length. Alternatives like `--longitudeDegrees 75 --latitudeDegrees 39 --heightMeters 123` would be pretty inconvenient, and there's no way to model the constraint that the first two parameters are required (together), and the last one is optional. So I think that the current solution is a reasonable middle ground...

