### PR TITLE
Avoid duplicate storage of batch- and feature IDs

### DIFF
--- a/specs/data/migration/golden_gltf/Batched/BatchedAnimated/batchedAnimated.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedAnimated/batchedAnimated.gltf
@@ -37,8 +37,8 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
+      "componentType": 5123,
+      "count": 360,
       "bufferView": 1,
       "byteOffset": 0
     },
@@ -46,8 +46,8 @@
       "type": "VEC3",
       "componentType": 5126,
       "count": 3,
-      "bufferView": 1,
-      "byteOffset": 960
+      "bufferView": 2,
+      "byteOffset": 0
     },
     {
       "type": "SCALAR",
@@ -59,15 +59,8 @@
       "min": [
         0
       ],
-      "bufferView": 1,
-      "byteOffset": 996
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5123,
-      "count": 360,
       "bufferView": 2,
-      "byteOffset": 0
+      "byteOffset": 36
     }
   ],
   "bufferViews": [
@@ -81,39 +74,39 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 1008
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7728,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8448,
+      "byteOffset": 7440,
+      "byteLength": 48
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 7488,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8458,
+      "byteOffset": 7498,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8498,
+      "byteOffset": 7538,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8538,
+      "byteOffset": 7578,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8578
+      "byteLength": 7618
     }
   ],
   "materials": [
@@ -134,7 +127,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 6,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [

--- a/specs/data/migration/golden_gltf/Batched/BatchedColors/batchedColors.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedColors/batchedColors.gltf
@@ -37,142 +37,72 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
+      "componentType": 5123,
+      "count": 36,
       "bufferView": 1,
       "byteOffset": 0
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 2,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 3,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 4,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 5,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 6,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 7,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 8,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 9,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 10,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5123,
-      "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 72
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 144
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 216
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 288
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 360
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 432
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 504
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 576
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 648
     }
   ],
@@ -187,102 +117,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 8640,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 9600,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 10560,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 11520,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 12480,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 13440,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 14400,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 15360,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 16320,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 17040,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 17050,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 17090,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 17130,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 17170
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -408,7 +270,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 13,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -425,11 +287,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 3
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 1,
-          "indices": 14,
+          "indices": 4,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -446,11 +308,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 4
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 2,
-          "indices": 15,
+          "indices": 5,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -467,11 +329,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 5
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 3,
-          "indices": 16,
+          "indices": 6,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -488,11 +350,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 6
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 4,
-          "indices": 17,
+          "indices": 7,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -509,11 +371,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 7
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 5,
-          "indices": 18,
+          "indices": 8,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -530,11 +392,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 8
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 6,
-          "indices": 19,
+          "indices": 9,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -551,11 +413,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 9
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 7,
-          "indices": 20,
+          "indices": 10,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -572,11 +434,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 10
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 8,
-          "indices": 21,
+          "indices": 11,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -593,11 +455,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 11
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 9,
-          "indices": 22,
+          "indices": 12,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -694,16 +556,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 12
+              "values": 2
             },
             "Longitude": {
-              "values": 13
+              "values": 3
             },
             "Latitude": {
-              "values": 14
+              "values": 4
             },
             "Height": {
-              "values": 15
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedColorsMix/batchedColorsMix.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedColorsMix/batchedColorsMix.gltf
@@ -37,142 +37,72 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
+      "componentType": 5123,
+      "count": 36,
       "bufferView": 1,
       "byteOffset": 0
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 2,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 3,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 4,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 5,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 6,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 7,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 8,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 9,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 10,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5123,
-      "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 72
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 144
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 216
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 288
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 360
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 432
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 504
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 576
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 648
     }
   ],
@@ -187,102 +117,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 8640,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 9600,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 10560,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 11520,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 12480,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 13440,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 14400,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 15360,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 16320,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 17040,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 17050,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 17090,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 17130,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 17170
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -418,7 +280,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 13,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -435,11 +297,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 3
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 1,
-          "indices": 14,
+          "indices": 4,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -456,11 +318,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 4
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 2,
-          "indices": 15,
+          "indices": 5,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -477,11 +339,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 5
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 3,
-          "indices": 16,
+          "indices": 6,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -498,11 +360,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 6
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 4,
-          "indices": 17,
+          "indices": 7,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -519,11 +381,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 7
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 5,
-          "indices": 18,
+          "indices": 8,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -540,11 +402,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 8
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 6,
-          "indices": 19,
+          "indices": 9,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -561,11 +423,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 9
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 7,
-          "indices": 20,
+          "indices": 10,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -582,11 +444,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 10
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 8,
-          "indices": 21,
+          "indices": 11,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -603,11 +465,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 11
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 9,
-          "indices": 22,
+          "indices": 12,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -704,16 +566,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 12
+              "values": 2
             },
             "Longitude": {
-              "values": 13
+              "values": 3
             },
             "Latitude": {
-              "values": 14
+              "values": 4
             },
             "Height": {
-              "values": 15
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedColorsTranslucent/batchedColorsTranslucent.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedColorsTranslucent/batchedColorsTranslucent.gltf
@@ -37,142 +37,72 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
+      "componentType": 5123,
+      "count": 36,
       "bufferView": 1,
       "byteOffset": 0
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 2,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 3,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 4,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 5,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 6,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 7,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 8,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 9,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 10,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5123,
-      "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 72
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 144
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 216
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 288
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 360
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 432
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 504
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 576
     },
     {
       "type": "SCALAR",
       "componentType": 5123,
       "count": 36,
-      "bufferView": 11,
+      "bufferView": 1,
       "byteOffset": 648
     }
   ],
@@ -187,102 +117,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 8640,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 9600,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 10560,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 11520,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 12480,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 13440,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 14400,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 15360,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 16320,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 17040,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 17050,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 17090,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 17130,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 17170
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -428,7 +290,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 13,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -445,11 +307,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 3
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 1,
-          "indices": 14,
+          "indices": 4,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -466,11 +328,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 4
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 2,
-          "indices": 15,
+          "indices": 5,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -487,11 +349,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 5
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 3,
-          "indices": 16,
+          "indices": 6,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -508,11 +370,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 6
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 4,
-          "indices": 17,
+          "indices": 7,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -529,11 +391,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 7
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 5,
-          "indices": 18,
+          "indices": 8,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -550,11 +412,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 8
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 6,
-          "indices": 19,
+          "indices": 9,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -571,11 +433,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 9
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 7,
-          "indices": 20,
+          "indices": 10,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -592,11 +454,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 10
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 8,
-          "indices": 21,
+          "indices": 11,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -613,11 +475,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 11
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 9,
-          "indices": 22,
+          "indices": 12,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -714,16 +576,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 12
+              "values": 2
             },
             "Longitude": {
-              "values": 13
+              "values": 3
             },
             "Latitude": {
-              "values": 14
+              "values": 4
             },
             "Height": {
-              "values": 15
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedDeprecated1/batchedDeprecated1.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedDeprecated1/batchedDeprecated1.gltf
@@ -37,13 +37,6 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 0,
-      "byteOffset": 28
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
       "bufferView": 1,
@@ -54,41 +47,41 @@
     {
       "buffer": 0,
       "byteOffset": 0,
-      "byteLength": 7680,
-      "byteStride": 32,
+      "byteLength": 6720,
+      "byteStride": 28,
       "target": 34962
     },
     {
       "buffer": 0,
-      "byteOffset": 7680,
+      "byteOffset": 6720,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -105,12 +98,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "BATCHID": 2,
-            "_FEATURE_ID_0": 3
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [

--- a/specs/data/migration/golden_gltf/Batched/BatchedDeprecated2/batchedDeprecated2.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedDeprecated2/batchedDeprecated2.gltf
@@ -37,13 +37,6 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 0,
-      "byteOffset": 28
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
       "bufferView": 1,
@@ -54,41 +47,41 @@
     {
       "buffer": 0,
       "byteOffset": 0,
-      "byteLength": 7680,
-      "byteStride": 32,
+      "byteLength": 6720,
+      "byteStride": 28,
       "target": 34962
     },
     {
       "buffer": 0,
-      "byteOffset": 7680,
+      "byteOffset": 6720,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -105,12 +98,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "BATCHID": 2,
-            "_FEATURE_ID_0": 3
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [

--- a/specs/data/migration/golden_gltf/Batched/BatchedExpiration/batchedExpiration.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedExpiration/batchedExpiration.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -211,16 +199,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedTextured/batchedTextured.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedTextured/batchedTextured.gltf
@@ -44,23 +44,16 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 2,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 3,
+      "bufferView": 2,
       "byteOffset": 0
     }
   ],
   "bufferViews": [
     {
       "buffer": 0,
-      "byteOffset": 10320,
+      "byteOffset": 9360,
       "byteLength": 15490
     },
     {
@@ -73,32 +66,27 @@
     {
       "buffer": 0,
       "byteOffset": 8640,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 9600,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 25816,
+      "byteOffset": 24856,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 25826,
+      "byteOffset": 24866,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 25866,
+      "byteOffset": 24906,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 25906,
+      "byteOffset": 24946,
       "byteLength": 40
     }
   ],
@@ -126,7 +114,7 @@
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 25946
+      "byteLength": 24986
     }
   ],
   "materials": [
@@ -151,7 +139,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 5,
+          "indices": 4,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -248,16 +236,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 4
+              "values": 3
             },
             "Longitude": {
-              "values": 5
+              "values": 4
             },
             "Latitude": {
-              "values": 6
+              "values": 5
             },
             "Height": {
-              "values": 7
+              "values": 6
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedTranslucent/batchedTranslucent.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedTranslucent/batchedTranslucent.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -122,7 +110,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -219,16 +207,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedTranslucentOpaqueMix/batchedTranslucentOpaqueMix.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedTranslucentOpaqueMix/batchedTranslucentOpaqueMix.gltf
@@ -37,30 +37,16 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
+      "componentType": 5123,
+      "count": 180,
       "bufferView": 1,
       "byteOffset": 0
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 2,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 180,
-      "bufferView": 3,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
-      "componentType": 5123,
-      "count": 180,
-      "bufferView": 3,
+      "bufferView": 1,
       "byteOffset": 360
     }
   ],
@@ -75,46 +61,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960,
-      "byteStride": 4,
-      "target": 34962
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 8640,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 9360,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 9370,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 9410,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 9450,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 9490
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -148,7 +122,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 5,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -165,11 +139,11 @@
           "attributes": {
             "POSITION": 0,
             "NORMAL": 1,
-            "_FEATURE_ID_0": 3
+            "_FEATURE_ID_0": 2
           },
           "mode": 4,
           "material": 1,
-          "indices": 6,
+          "indices": 4,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -266,16 +240,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 4
+              "values": 2
             },
             "Longitude": {
-              "values": 5
+              "values": 3
             },
             "Latitude": {
-              "values": 6
+              "values": 4
             },
             "Height": {
-              "values": 7
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWGS84/batchedWGS84.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWGS84/batchedWGS84.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -201,16 +189,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithBatchTable/batchedWithBatchTable.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithBatchTable/batchedWithBatchTable.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,59 +54,54 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8530,
+      "byteOffset": 7570,
       "byteLength": 290
     },
     {
       "buffer": 0,
-      "byteOffset": 8820,
+      "byteOffset": 7860,
       "byteLength": 44
     },
     {
       "buffer": 0,
-      "byteOffset": 8864,
+      "byteOffset": 7904,
       "byteLength": 210
     },
     {
       "buffer": 0,
-      "byteOffset": 9074,
+      "byteOffset": 8114,
       "byteLength": 124
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 9198
+      "byteLength": 8238
     }
   ],
   "materials": [
@@ -134,7 +122,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -245,24 +233,24 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             },
             "info": {
-              "values": 7,
-              "stringOffsets": 8
+              "values": 6,
+              "stringOffsets": 7
             },
             "rooms": {
-              "values": 9,
-              "stringOffsets": 10
+              "values": 8,
+              "stringOffsets": 9
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithBatchTableBinary/batchedWithBatchTableBinary.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithBatchTableBinary/batchedWithBatchTableBinary.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,49 +54,44 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8530,
+      "byteOffset": 7570,
       "byteLength": 240
     },
     {
       "buffer": 0,
-      "byteOffset": 8770,
+      "byteOffset": 7810,
       "byteLength": 10
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8780
+      "byteLength": 7820
     }
   ],
   "materials": [
@@ -124,7 +112,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -235,22 +223,22 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             },
             "cartographic": {
-              "values": 7
+              "values": 6
             },
             "code": {
-              "values": 8
+              "values": 7
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithBoundingSphere/batchedWithBoundingSphere.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithBoundingSphere/batchedWithBoundingSphere.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -211,16 +199,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithCopyright/batchedWithCopyright.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithCopyright/batchedWithCopyright.gltf
@@ -38,16 +38,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -62,39 +55,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -115,7 +103,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -212,16 +200,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithRtcCenter/batchedWithRtcCenter.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithRtcCenter/batchedWithRtcCenter.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -211,16 +199,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithTransformBox/batchedWithTransformBox.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithTransformBox/batchedWithTransformBox.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -201,16 +189,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithTransformRegion/batchedWithTransformRegion.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithTransformRegion/batchedWithTransformRegion.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -201,16 +189,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithTransformSphere/batchedWithTransformSphere.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithTransformSphere/batchedWithTransformSphere.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,39 +54,34 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 8400,
+      "byteOffset": 7440,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 8410,
+      "byteOffset": 7450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8450,
+      "byteOffset": 7490,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 8490,
+      "byteOffset": 7530,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8530
+      "byteLength": 7570
     }
   ],
   "materials": [
@@ -114,7 +102,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -201,16 +189,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithVertexColors/batchedWithVertexColors.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithVertexColors/batchedWithVertexColors.gltf
@@ -45,16 +45,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -69,39 +62,34 @@
     {
       "buffer": 0,
       "byteOffset": 7680,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 8640,
       "byteLength": 720,
       "target": 34963
     },
     {
       "buffer": 0,
-      "byteOffset": 9360,
+      "byteOffset": 8400,
       "byteLength": 10
     },
     {
       "buffer": 0,
-      "byteOffset": 9370,
+      "byteOffset": 8410,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 9410,
+      "byteOffset": 8450,
       "byteLength": 40
     },
     {
       "buffer": 0,
-      "byteOffset": 9450,
+      "byteOffset": 8490,
       "byteLength": 40
     }
   ],
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 9490
+      "byteLength": 8530
     }
   ],
   "materials": [
@@ -123,7 +111,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 5,
+          "indices": 4,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [
@@ -220,16 +208,16 @@
           "count": 10,
           "properties": {
             "id": {
-              "values": 3
+              "values": 2
             },
             "Longitude": {
-              "values": 4
+              "values": 3
             },
             "Latitude": {
-              "values": 5
+              "values": 4
             },
             "Height": {
-              "values": 6
+              "values": 5
             }
           }
         }

--- a/specs/data/migration/golden_gltf/Batched/BatchedWithoutBatchTable/batchedWithoutBatchTable.gltf
+++ b/specs/data/migration/golden_gltf/Batched/BatchedWithoutBatchTable/batchedWithoutBatchTable.gltf
@@ -37,16 +37,9 @@
     },
     {
       "type": "SCALAR",
-      "componentType": 5126,
-      "count": 240,
-      "bufferView": 1,
-      "byteOffset": 0
-    },
-    {
-      "type": "SCALAR",
       "componentType": 5123,
       "count": 360,
-      "bufferView": 2,
+      "bufferView": 1,
       "byteOffset": 0
     }
   ],
@@ -61,11 +54,6 @@
     {
       "buffer": 0,
       "byteOffset": 6720,
-      "byteLength": 960
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 7680,
       "byteLength": 720,
       "target": 34963
     }
@@ -73,7 +61,7 @@
   "buffers": [
     {
       "name": "buffer",
-      "byteLength": 8400
+      "byteLength": 7440
     }
   ],
   "materials": [
@@ -94,7 +82,7 @@
           },
           "mode": 4,
           "material": 0,
-          "indices": 4,
+          "indices": 3,
           "extensions": {
             "EXT_mesh_features": {
               "featureIds": [

--- a/specs/tools/migration/TileFormatsMigrationB3dmSpec.ts
+++ b/specs/tools/migration/TileFormatsMigrationB3dmSpec.ts
@@ -1,0 +1,135 @@
+// Note: Most of the migrations are tested in the `TileFormatsMigrationSpec`,
+// generically, independent of the input type, and by comparing the results
+// to "golden" reference files.
+// The tests here only focus on narrow aspects of the migration of B3DM.
+
+import { Document } from "@gltf-transform/core";
+import { Accessor } from "@gltf-transform/core";
+
+import { GltfTransform } from "../../../src/tools";
+import { TileFormatsMigrationB3dm } from "../../../src/tools";
+
+import { TileFormats } from "../../../src/tilesets";
+
+// Create a glTF-Transform document that only contains two mesh primitives
+// that have the `_BATCHID` and `BATCHID` attributes that are specific
+// for GLB in B3DM. The attributes will refer to the same accessors,
+// and the migration should convert them into `_FEATURE_ID_` attributes
+// without duplicating the accessor data. This is a regression test
+// for https://github.com/CesiumGS/3d-tiles-tools/issues/123
+async function createTileFormatsMigrationB3dmSpecDocument() {
+  const document = new Document();
+  const buffer = document.createBuffer();
+
+  const mesh = document.createMesh();
+
+  // Create two accessors that will be used as BATCHID
+  // acccessors in numltiple primitives
+  const accessor0 = document.createAccessor();
+  accessor0.setBuffer(buffer);
+  accessor0.setType(Accessor.Type.SCALAR);
+  const ids0 = [0, 1, 0, 1, 0, 1, 0, 1, 0];
+  accessor0.setArray(new Int16Array(ids0));
+
+  const accessor1 = document.createAccessor();
+  accessor1.setBuffer(buffer);
+  accessor1.setType(Accessor.Type.SCALAR);
+  const ids1 = [0, 1, 0, 1, 0, 1, 0, 1, 0];
+  accessor1.setArray(new Int16Array(ids1));
+
+  // Create 4 primitives:
+
+  // The first two primitives refer to the first accessor, as
+  // the  "_BATCHID" and the (legacy) "BATCHID" attribute
+  const primitive0a = document.createPrimitive();
+  primitive0a.setAttribute("_BATCHID", accessor0);
+  mesh.addPrimitive(primitive0a);
+
+  const primitive0b = document.createPrimitive();
+  primitive0b.setAttribute("BATCHID", accessor0);
+  mesh.addPrimitive(primitive0b);
+
+  // The first two primitives refer to the second accessor, as
+  // the  "_BATCHID" and the (legacy) "BATCHID" attribute
+  const primitive1a = document.createPrimitive();
+  primitive1a.setAttribute("_BATCHID", accessor1);
+  mesh.addPrimitive(primitive1a);
+
+  const primitive1b = document.createPrimitive();
+  primitive1b.setAttribute("BATCHID", accessor1);
+  mesh.addPrimitive(primitive1b);
+
+  return document;
+}
+
+// Create the buffer with the data of a B3DM file that contains the
+// GLB of the given glTF-Transform document as its payload, with
+// a dummy feature table that has a batch length of 2 (to enforce
+// taking the path that handles creating a property table)
+async function createB3dmBuffer(document: Document) {
+  const io = await GltfTransform.getIO();
+  const inputGlbData = await io.writeBinary(document);
+  const featureTableJson = {
+    BATCH_LENGTH: 2,
+  };
+  const featureTableBinary = Buffer.alloc(0);
+  const batchTableJson = {};
+  const batchTableBinary = Buffer.alloc(0);
+
+  const inputB3dmTileData = TileFormats.createB3dmTileDataFromGlb(
+    Buffer.from(inputGlbData),
+    featureTableJson,
+    featureTableBinary,
+    batchTableJson,
+    batchTableBinary
+  );
+  const b3dmBuffer = TileFormats.createTileDataBuffer(inputB3dmTileData);
+  return b3dmBuffer;
+}
+
+describe("TileFormatsMigrationB3dm", function () {
+  it("does not duplicate data when converting batch IDs to feature IDs", async function () {
+    const io = await GltfTransform.getIO();
+
+    const inputDocument = await createTileFormatsMigrationB3dmSpecDocument();
+
+    const inputJsonDocument = await io.writeJSON(inputDocument);
+    const inputJson = inputJsonDocument.json;
+
+    // Initially, there should be two accessors, and they should
+    // be used as the _BATCHID and BATCHID attributes inside
+    // the mesh primitives
+    const actualInputNumAccessors = inputJson.accessors?.length;
+    expect(actualInputNumAccessors).toBe(2);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const inputPrimitives = inputJson.meshes![0].primitives as any[];
+    expect(inputPrimitives[0].attributes).toEqual({ _BATCHID: 0 });
+    expect(inputPrimitives[1].attributes).toEqual({ BATCHID: 0 });
+    expect(inputPrimitives[2].attributes).toEqual({ _BATCHID: 1 });
+    expect(inputPrimitives[3].attributes).toEqual({ BATCHID: 1 });
+
+    const b3dmBuffer = await createB3dmBuffer(inputDocument);
+    const outputGlb = await TileFormatsMigrationB3dm.convertB3dmToGlb(
+      b3dmBuffer
+    );
+    const outputDocument = await io.readBinary(outputGlb);
+
+    const outputJsonDocument = await io.writeJSON(outputDocument);
+    const outputJson = outputJsonDocument.json;
+
+    // After the migration, there should STILL be only two accessors, and
+    // they should be used as the _FEATURE_ID attributes inside the mesh
+    // primitives
+
+    const actualOutputNumAccessors = outputJson.accessors?.length;
+    expect(actualOutputNumAccessors).toBe(2);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const outputPrimitives = outputJson.meshes![0].primitives as any[];
+    expect(outputPrimitives[0].attributes).toEqual({ _FEATURE_ID_0: 0 });
+    expect(outputPrimitives[1].attributes).toEqual({ _FEATURE_ID_0: 0 });
+    expect(outputPrimitives[2].attributes).toEqual({ _FEATURE_ID_0: 1 });
+    expect(outputPrimitives[3].attributes).toEqual({ _FEATURE_ID_0: 1 });
+  });
+});

--- a/src/tools/migration/TileFormatsMigrationB3dm.ts
+++ b/src/tools/migration/TileFormatsMigrationB3dm.ts
@@ -1,3 +1,5 @@
+import { Accessor } from "@gltf-transform/core";
+
 import { BatchTable } from "../../structure";
 import { B3dmFeatureTable } from "../../structure";
 
@@ -74,6 +76,8 @@ export class TileFormatsMigrationB3dm {
           batchTableBinary,
           numRows
         );
+
+      const batchIdToFeatureIdAccessor = new Map<Accessor, Accessor>();
       const meshes = root.listMeshes();
       for (const mesh of meshes) {
         const primitives = mesh.listPrimitives();
@@ -83,12 +87,19 @@ export class TileFormatsMigrationB3dm {
           const featureId =
             TileTableDataToMeshFeatures.convertBatchIdToMeshFeatures(
               document,
-              primitive
+              primitive,
+              batchIdToFeatureIdAccessor
             );
           if (propertyTable) {
             featureId.setPropertyTable(propertyTable);
           }
         }
+      }
+
+      // Dispose all former batch ID accessors that have been
+      // converted into feature ID accessors
+      for (const batchIdAccessor of batchIdToFeatureIdAccessor.keys()) {
+        batchIdAccessor.dispose();
       }
     }
 

--- a/src/tools/migration/TileTableDataToMeshFeatures.ts
+++ b/src/tools/migration/TileTableDataToMeshFeatures.ts
@@ -18,21 +18,30 @@ const logger = Loggers.get("migration");
  */
 export class TileTableDataToMeshFeatures {
   /**
-   * Convert the `_BATCHID` attribute in the given primitive into
-   * an instance of the `ETX_mesh_features` extension that is
-   * associated with this primitive, storing the former `_BATCHID`
-   * attribute as a new `_FEATURE_ID_0` attribute.
+   * Convert the `_BATCHID` or `BATCHID` attribute in the given
+   * primitive into an instance of the `ETX_mesh_features`
+   * extension that is associated with this primitive, storing
+   * the former batch ID attribute as a new `_FEATURE_ID_0` attribute.
+   *
+   * Note that this will remove the former batch ID attributes
+   * in the given primitive to `null`, but it will not dispose
+   * the corresponding accessors. These have to be disposed
+   * after all primitives have been processed.
    *
    * @param document - The glTF-Transform document
    * @param primitive - The glTF-Transform primitive
+   * @param batchIdToFeatureIdAccessor - A mapping from former
+   * batch ID accessors to feature ID acccessors, to keep
+   * track of the accessors that have already been converted
    * @returns The glTF-Transform `FeatureId` object that has
    * been created
    * @throws TileFormatError If the given primitive does not
-   * contain a valid `_BATCHID` attribute.
+   * contain a valid `_BATCHID` or `BATCHID` attribute.
    */
   static convertBatchIdToMeshFeatures(
     document: Document,
-    primitive: Primitive
+    primitive: Primitive,
+    batchIdToFeatureIdAccessor: Map<Accessor, Accessor>
   ): FeatureId {
     let batchIdAttribute = primitive.getAttribute("_BATCHID");
     if (!batchIdAttribute) {
@@ -48,6 +57,7 @@ export class TileTableDataToMeshFeatures {
         );
       }
     }
+
     const batchIdsArray = batchIdAttribute.getArray();
     if (!batchIdsArray) {
       throw new TileFormatError(
@@ -55,22 +65,31 @@ export class TileTableDataToMeshFeatures {
       );
     }
 
-    const extMeshFeatures = document.createExtension(EXTMeshFeatures);
+    // Re-use any existing feature ID accessor that may already
+    // have been created for the batch ID accessor
+    let featureIdAccessor = batchIdToFeatureIdAccessor.get(batchIdAttribute);
+    if (featureIdAccessor === undefined) {
+      // Create a new accessor for the _FEATURE_ID_0,
+      // containing the values of the _BATCHID accessor
+      featureIdAccessor = document.createAccessor();
+      const buffer = document.getRoot().listBuffers()[0];
+      featureIdAccessor.setBuffer(buffer);
+      featureIdAccessor.setType(Accessor.Type.SCALAR);
+      featureIdAccessor.setArray(batchIdsArray);
 
-    // Assign a new accessor for the _FEATURE_ID_0 to the primitive,
-    // containing the values of the _BATCHID accessor
-    const featureIdAccessor = document.createAccessor();
-    const buffer = document.getRoot().listBuffers()[0];
-    featureIdAccessor.setBuffer(buffer);
-    featureIdAccessor.setType(Accessor.Type.SCALAR);
-    featureIdAccessor.setArray(batchIdsArray);
+      batchIdToFeatureIdAccessor.set(batchIdAttribute, featureIdAccessor);
+    }
+
+    // Assign the feature ID accessor to the primitive
     primitive.setAttribute("_FEATURE_ID_0", featureIdAccessor);
 
-    // Remove the former _BATCHID attribute
+    // Remove the former _BATCHID OR BATCHID attribute
     primitive.setAttribute("_BATCHID", null);
+    primitive.setAttribute("BATCHID", null);
 
     // Creates the mesh features extension object that
     // refers to the _FEATURE_ID_0 attribute
+    const extMeshFeatures = document.createExtension(EXTMeshFeatures);
     const meshFeatures = extMeshFeatures.createMeshFeatures();
     const featureId = extMeshFeatures.createFeatureId();
     featureId.setAttribute(0);
@@ -79,6 +98,7 @@ export class TileTableDataToMeshFeatures {
     meshFeatures.addFeatureId(featureId);
 
     primitive.setExtension("EXT_mesh_features", meshFeatures);
+
     return featureId;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-tools/issues/123 

As noted in the issue: When the GLB in a B3DM re-used the same batch ID accessor for multiple primitives, then the conversion into feature IDs did cause duplicated storage of IDs. For example, when the input contained 
```
Accessors: 2
Mesh 0 of 1
  Primitive 0 of 4
Attributes:  { _BATCHID: 0 }
  Primitive 1 of 4
Attributes:  { BATCHID: 0 }
  Primitive 2 of 4
Attributes:  { _BATCHID: 1 }
  Primitive 3 of 4
Attributes:  { BATCHID: 1 }
```
then the output contained
```
Accessors:  6
Mesh 0 of 1
  Primitive 0 of 4
Attributes:  { _FEATURE_ID_0: 4 }
  Primitive 1 of 4
Attributes:  { BATCHID: 0, _FEATURE_ID_0: 1 }
  Primitive 2 of 4
Attributes:  { _FEATURE_ID_0: 5 }
  Primitive 3 of 4
Attributes:  { BATCHID: 2, _FEATURE_ID_0: 3 }
```

This PR fixes this by keeping track of the accessors that have already been converted from batch ID into feature ID, and properly disposing of the former batch ID accessors, resulting in this:
```
Accessors:  2
Mesh 0 of 1
  Primitive 0 of 4
Attributes:  { _FEATURE_ID_0: 0 }
  Primitive 1 of 4
Attributes:  { _FEATURE_ID_0: 0 }
  Primitive 2 of 4
Attributes:  { _FEATURE_ID_0: 1 }
  Primitive 3 of 4
Attributes:  { _FEATURE_ID_0: 1 }
```

There are no tests yet, but the output above has been created with the following snippet, which will be converted into a test soon:

```typescript
import { Accessor, Document } from "@gltf-transform/core";
import { TileFormats } from "./src/tilesets";
import { GltfTransform, TileFormatsMigrationB3dm } from "./src/tools";

async function createDocument() {
  const document = new Document();
  const buffer = document.createBuffer();

  const mesh = document.createMesh();

  // Create two accessors that will be used as BATCHID
  // acccessors in numltiple primitives
  const accessor0 = document.createAccessor();
  accessor0.setBuffer(buffer);
  accessor0.setType(Accessor.Type.SCALAR);
  const ids0 = [0, 1, 0, 1, 0, 1, 0, 1, 0];
  accessor0.setArray(new Int16Array(ids0));

  const accessor1 = document.createAccessor();
  accessor1.setBuffer(buffer);
  accessor1.setType(Accessor.Type.SCALAR);
  const ids1 = [0, 1, 0, 1, 0, 1, 0, 1, 0];
  accessor1.setArray(new Int16Array(ids1));

  // Create 4 primitives:

  // The first two primitives refer to the first accessor, as
  // the  "_BATCHID" and the (legacy) "BATCHID" attribute
  const primitive0a = document.createPrimitive();
  primitive0a.setAttribute("_BATCHID", accessor0);
  mesh.addPrimitive(primitive0a);

  const primitive0b = document.createPrimitive();
  primitive0b.setAttribute("BATCHID", accessor0);
  mesh.addPrimitive(primitive0b);

  // The first two primitives refer to the second accessor, as
  // the  "_BATCHID" and the (legacy) "BATCHID" attribute
  const primitive1a = document.createPrimitive();
  primitive1a.setAttribute("_BATCHID", accessor1);
  mesh.addPrimitive(primitive1a);

  const primitive1b = document.createPrimitive();
  primitive1b.setAttribute("BATCHID", accessor1);
  mesh.addPrimitive(primitive1b);

  return document;
}

async function createB3dmBuffer(document: Document) {
  const io = await GltfTransform.getIO();
  const inputGlbData = await io.writeBinary(document);
  const featureTableJson = {
    BATCH_LENGTH: 2,
  };
  const featureTableBinary = Buffer.alloc(0);
  const batchTableJson = {};
  const batchTableBinary = Buffer.alloc(0);

  const inputB3dmTileData = TileFormats.createB3dmTileDataFromGlb(
    Buffer.from(inputGlbData),
    featureTableJson,
    featureTableBinary,
    batchTableJson,
    batchTableBinary
  );
  const b3dmBuffer = TileFormats.createTileDataBuffer(inputB3dmTileData);
  return b3dmBuffer;
}

async function printInfo(document: Document) {
  const io = await GltfTransform.getIO();
  const jsonDocument = await io.writeJSON(document);
  const json = jsonDocument.json;

  console.log("Accessors: ", json.accessors?.length);

  const meshes = json.meshes ?? [];
  for (let m = 0; m < meshes.length; m++) {
    console.log("Mesh " + m + " of " + meshes.length);
    const mesh = meshes[m];
    const primitives = mesh.primitives ?? [];
    for (let p = 0; p < primitives.length; p++) {
      console.log("  Primitive " + p + " of " + primitives.length);
      const primitive = primitives[p];
      const attributes = primitive.attributes;
      console.log("Attributes: ", attributes);
    }
  }
}

async function runMigrationTest() {
  const inputDocument = await createDocument();
  console.log("Input document:");
  printInfo(inputDocument);

  const io = await GltfTransform.getIO();
  const b3dmBuffer = await createB3dmBuffer(inputDocument);
  const outputGlb = await TileFormatsMigrationB3dm.convertB3dmToGlb(b3dmBuffer);
  const outputDocument = await io.readBinary(outputGlb);

  console.log("Output document:");
  printInfo(outputDocument);

  console.log("done");
}

runMigrationTest();
```
