### PR TITLE
Add `jsonOnly` option to `merge` command

### DIFF
--- a/src/cli/ToolsMain.ts
+++ b/src/cli/ToolsMain.ts
@@ -553,14 +553,15 @@ export class ToolsMain {
     logger.debug(`Executing upgrade DONE`);
   }
 
-  static async merge(inputs: string[], output: string, force: boolean) {
+  static async merge(inputs: string[], output: string, force: boolean, jsonOnly: boolean) {
     logger.debug(`Executing merge`);
     logger.debug(`  inputs: ${inputs}`);
     logger.debug(`  output: ${output}`);
     logger.debug(`  force: ${force}`);
+    logger.debug(`  jsonOnly: ${jsonOnly}`);
 
     ToolsMain.ensureCanWrite(output, force);
-    await TilesetOperations.merge(inputs, output, force);
+    await TilesetOperations.merge(inputs, output, force, jsonOnly);
 
     logger.debug(`Executing merge DONE`);
   }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -257,7 +257,15 @@ function parseToolArgs(a: string[]) {
     .command(
       "merge",
       "Merge any number of tilesets together into a single tileset.",
-      { i: inputArrayDefinition, o: outputStringDefinition }
+      { 
+        i: inputArrayDefinition, 
+        o: outputStringDefinition, 
+        jsonOnly: {
+          default: false,
+          description: "Whether to copy resources to output directory - tileset.json and tile contents",
+          type: "boolean",
+        },
+      }
     )
     .command(
       "upgrade",
@@ -536,7 +544,8 @@ async function runCommand(command: string, toolArgs: any, optionArgs: any) {
       parsedOptionArgs
     );
   } else if (command === "merge") {
-    await ToolsMain.merge(inputs, output, force);
+    const jsonOnly = toolArgs.jsonOnly === true;
+    await ToolsMain.merge(inputs, output, force, jsonOnly);
   } else if (command === "pipeline") {
     await ToolsMain.pipeline(input, force);
   } else if (command === "analyze") {

--- a/src/tools/tilesetProcessing/TilesetMerger.ts
+++ b/src/tools/tilesetProcessing/TilesetMerger.ts
@@ -72,6 +72,7 @@ export class TilesetMerger {
    * @param tilesetSourceNames - The tileset source names
    * @param tilesetTargetName - The tileset target name
    * @param overwrite - Whether target files should be overwritten
+   * @param jsonOnly - Whether to copy resources to output directory 
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed
    * @throws TilesetError When the output already exists
@@ -80,7 +81,8 @@ export class TilesetMerger {
   async merge(
     tilesetSourceNames: string[],
     tilesetTargetName: string,
-    overwrite: boolean
+    overwrite: boolean,
+    jsonOnly: boolean
   ): Promise<void> {
     // Create the sources and target
     for (const tilesetSourceName of tilesetSourceNames) {
@@ -106,7 +108,11 @@ export class TilesetMerger {
       const tilesetSource = TilesetSources.createAndOpen(tilesetSourceName);
       this.tilesetSources.push(tilesetSource);
       this.tilesetSourceJsonFileNames.push(tilesetSourceJsonFileName);
-      this.tilesetSourceIdentifiers.push(tilesetSourceIdentifier);
+      this.tilesetSourceIdentifiers.push(
+        !jsonOnly ? 
+        tilesetSourceIdentifier : 
+        tilesetSourceName 
+      );
     }
 
     this.tilesetTargetJsonFileName =
@@ -117,7 +123,7 @@ export class TilesetMerger {
     );
 
     // Perform the actual merge
-    this.mergeInternal();
+    this.mergeInternal(jsonOnly);
 
     // Clean up by closing the sources and the target
     for (const tilesetSource of this.tilesetSources) {
@@ -134,7 +140,7 @@ export class TilesetMerger {
   /**
    * Internal method for `merge`
    */
-  private mergeInternal() {
+  private mergeInternal(jsonOnly: boolean) {
     if (
       this.tilesetSources.length == 0 ||
       !this.tilesetTarget ||
@@ -192,7 +198,8 @@ export class TilesetMerger {
     );
 
     // Copy the resources from the sources to the target
-    this.copyResources();
+    if (!jsonOnly)
+      this.copyResources();
   }
 
   /**

--- a/src/tools/tilesetProcessing/TilesetOperations.ts
+++ b/src/tools/tilesetProcessing/TilesetOperations.ts
@@ -48,6 +48,7 @@ export class TilesetOperations {
    * @param tilesetTargetName - The tileset target name
    * @param overwrite - Whether the target should be overwritten if
    * it already exists
+   * @param jsonOnly - Whether to copy resources to output directory 
    * @returns A promise that resolves when the process is finished
    * @throws TilesetError When the input could not be processed,
    * or when the output already exists and `overwrite` was `false`.
@@ -55,10 +56,11 @@ export class TilesetOperations {
   static async merge(
     tilesetSourceNames: string[],
     tilesetTargetName: string,
-    overwrite: boolean
+    overwrite: boolean,
+    jsonOnly: boolean
   ): Promise<void> {
     const tilesetMerger = new TilesetMerger();
-    await tilesetMerger.merge(tilesetSourceNames, tilesetTargetName, overwrite);
+    await tilesetMerger.merge(tilesetSourceNames, tilesetTargetName, overwrite, jsonOnly);
   }
 
   /**


### PR DESCRIPTION
Following discussion thread https://github.com/CesiumGS/3d-tiles-tools/issues/44 

This option is meant to avoid copying resources (tileset.json and tile contents) when merging multiple input tilesets. Results in a tileset.json that references input tilesets where they are stored.

Can add another commit to remove the `--jsonOnly` flag from the `merge` command to instead create a new command, `mergeJson `