### PR TITLE
mergeJson: Set merged tileset children uri to relative path to output directory

### DIFF
--- a/specs/tools/tilesetProcessing/TilesetMergerSpec.ts
+++ b/specs/tools/tilesetProcessing/TilesetMergerSpec.ts
@@ -90,8 +90,8 @@ describe("TilesetMerger", function () {
     actualContentUris.sort();
 
     const expectedContentUris = [
-      "specs/data/mergeTilesets/basicMerge/TilesetA/tileset.json",
-      "specs/data/mergeTilesets/basicMerge/sub/TilesetA/tileset.json",
+      "../../mergeTilesets/basicMerge/TilesetA/tileset.json",
+      "../../mergeTilesets/basicMerge/sub/TilesetA/tileset.json",
     ];
     expect(actualContentUris).toEqual(expectedContentUris);
   });

--- a/src/tools/tilesetProcessing/TilesetMerger.ts
+++ b/src/tools/tilesetProcessing/TilesetMerger.ts
@@ -142,12 +142,17 @@ export class TilesetMerger {
       }
       const tilesetSourceDirectoryName = path.basename(tilesetSourceName);
 
-      const tilesetTargetDirectoryPath = Paths.isDirectory(tilesetTargetName) ? tilesetTargetName : path.dirname(tilesetTargetName)
+      const tilesetTargetDirectoryPath = Paths.isDirectory(tilesetTargetName)
+        ? tilesetTargetName
+        : path.dirname(tilesetTargetName);
       const tilesetSourceIdentifier = TilesetMerger.createIdentifier(
         tilesetSourceDirectoryName,
         this.tilesetSourceIdentifiers
       );
-      const relativeTilesetIdentifier = path.relative(tilesetTargetDirectoryPath, tilesetSourceDirectoryPath);
+      const relativeTilesetIdentifier = path.relative(
+        tilesetTargetDirectoryPath,
+        tilesetSourceDirectoryPath
+      );
 
       const tilesetSource = TilesetSources.createAndOpen(tilesetSourceName);
       this.tilesetSources.push(tilesetSource);

--- a/src/tools/tilesetProcessing/TilesetMerger.ts
+++ b/src/tools/tilesetProcessing/TilesetMerger.ts
@@ -134,24 +134,26 @@ export class TilesetMerger {
 
       // Determine an "identifier" for the tileset source
       // (see `tilesetSourceIdentifiers` for details)
-      let tilesetSourceDirectoryName;
+      let tilesetSourceDirectoryPath;
       if (Paths.isDirectory(tilesetSourceName)) {
-        tilesetSourceDirectoryName = path.basename(tilesetSourceName);
+        tilesetSourceDirectoryPath = tilesetSourceName;
       } else {
-        tilesetSourceDirectoryName = path.basename(
-          path.dirname(tilesetSourceName)
-        );
+        tilesetSourceDirectoryPath = path.dirname(tilesetSourceName);
       }
+      const tilesetSourceDirectoryName = path.basename(tilesetSourceName);
+
+      const tilesetTargetDirectoryPath = Paths.isDirectory(tilesetTargetName) ? tilesetTargetName : path.dirname(tilesetTargetName)
       const tilesetSourceIdentifier = TilesetMerger.createIdentifier(
         tilesetSourceDirectoryName,
         this.tilesetSourceIdentifiers
       );
+      const relativeTilesetIdentifier = path.relative(tilesetTargetDirectoryPath, tilesetSourceDirectoryPath);
 
       const tilesetSource = TilesetSources.createAndOpen(tilesetSourceName);
       this.tilesetSources.push(tilesetSource);
       this.tilesetSourceJsonFileNames.push(tilesetSourceJsonFileName);
       this.tilesetSourceIdentifiers.push(
-        !jsonOnly ? tilesetSourceIdentifier : tilesetSourceName
+        !jsonOnly ? tilesetSourceIdentifier : relativeTilesetIdentifier
       );
     }
 


### PR DESCRIPTION
In the initial PR, I did not correctly set the children URI for the merged tileset. This PR makes it so that children URI is the relative path from the output directory to the respective input tilesets jsons filepaths. 