### PR TITLE
Fix merge path handling

### DIFF
--- a/specs/tools/tilesetProcessing/TilesetMergerSpec.ts
+++ b/specs/tools/tilesetProcessing/TilesetMergerSpec.ts
@@ -7,31 +7,39 @@ import { TilesetOperations } from "../../../src/tools";
 import { SpecHelpers } from "../../SpecHelpers";
 
 const SPECS_DATA_BASE_DIRECTORY = SpecHelpers.getSpecsDataBaseDirectory();
-
-const basicInputs = [
-  SPECS_DATA_BASE_DIRECTORY + "/mergeTilesets/basicMerge/TilesetA",
-  SPECS_DATA_BASE_DIRECTORY + "/mergeTilesets/basicMerge/sub/TilesetA",
-];
-const basicOutput =
-  SPECS_DATA_BASE_DIRECTORY + "/output/mergeTilesets/basicMerge";
 const overwrite = true;
 
 describe("TilesetMerger", function () {
   afterEach(function () {
     SpecHelpers.forceDeleteDirectory(
-      SPECS_DATA_BASE_DIRECTORY + "/output/mergeTilesets"
+      Paths.join(SPECS_DATA_BASE_DIRECTORY, "output/mergeTilesets")
     );
   });
+  it("merges tilesets from directories into a single tileset directory", async function () {
+    const inputDirectories = [
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/TilesetA"
+      ),
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/sub/TilesetA"
+      ),
+    ];
+    const outputDirectory = Paths.join(
+      SPECS_DATA_BASE_DIRECTORY,
+      "output/mergeTilesets/basicMerge"
+    );
+    const outputFile = Paths.join(outputDirectory, "tileset.json");
 
-  it("merges tilesets into a single tileset", async function () {
-    await TilesetOperations.merge(basicInputs, basicOutput, overwrite);
+    await TilesetOperations.merge(inputDirectories, outputDirectory, overwrite);
 
     // Ensure that the output directory contains the expected files:
     // All files of the input, disambiguated for the same base name
     // (i.e. "TilesetA" and "TilesetA-0" - this is not specified,
     // but has to be assumed here)
     const actualRelativeFiles =
-      SpecHelpers.collectRelativeFileNames(basicOutput);
+      SpecHelpers.collectRelativeFileNames(outputDirectory);
     actualRelativeFiles.sort();
     const expectedRelativeFiles = [
       "TilesetA-0/ll.b3dm",
@@ -52,9 +60,7 @@ describe("TilesetMerger", function () {
 
     // Ensure that the single 'tileset.json' contains the
     // proper content URIs for the external tilesets:
-    const tilesetJsonBuffer = fs.readFileSync(
-      Paths.join(basicOutput, "tileset.json")
-    );
+    const tilesetJsonBuffer = fs.readFileSync(outputFile);
     const tileset = JSON.parse(tilesetJsonBuffer.toString());
     const actualContentUris = await SpecHelpers.collectExplicitContentUris(
       tileset.root
@@ -68,21 +74,52 @@ describe("TilesetMerger", function () {
     expect(actualContentUris).toEqual(expectedContentUris);
   });
 
-  it("merges tilesets into a single tileset for mergeJson", async function () {
-    await TilesetOperations.mergeJson(basicInputs, basicOutput, overwrite);
+  it("merges tilesets from files into a single tileset file", async function () {
+    const inputFiles = [
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/TilesetA/tileset.json"
+      ),
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/sub/TilesetA/tileset.json"
+      ),
+    ];
+    const outputDirectory = Paths.join(
+      SPECS_DATA_BASE_DIRECTORY,
+      "output/mergeTilesets/basicMerge"
+    );
+    const outputFile = Paths.join(outputDirectory, "tileset.json");
+
+    await TilesetOperations.merge(inputFiles, outputFile, overwrite);
 
     // Ensure that the output directory contains the expected files:
+    // All files of the input, disambiguated for the same base name
+    // (i.e. "TilesetA" and "TilesetA-0" - this is not specified,
+    // but has to be assumed here)
     const actualRelativeFiles =
-      SpecHelpers.collectRelativeFileNames(basicOutput);
+      SpecHelpers.collectRelativeFileNames(outputDirectory);
     actualRelativeFiles.sort();
-    const expectedRelativeFiles = ["tileset.json"];
+    const expectedRelativeFiles = [
+      "TilesetA-0/ll.b3dm",
+      "TilesetA-0/lr.b3dm",
+      "TilesetA-0/parent.b3dm",
+      "TilesetA-0/tileset.json",
+      "TilesetA-0/ul.b3dm",
+      "TilesetA-0/ur.b3dm",
+      "TilesetA/ll.b3dm",
+      "TilesetA/lr.b3dm",
+      "TilesetA/parent.b3dm",
+      "TilesetA/tileset.json",
+      "TilesetA/ul.b3dm",
+      "TilesetA/ur.b3dm",
+      "tileset.json",
+    ];
     expect(actualRelativeFiles).toEqual(expectedRelativeFiles);
 
     // Ensure that the single 'tileset.json' contains the
     // proper content URIs for the external tilesets:
-    const tilesetJsonBuffer = fs.readFileSync(
-      Paths.join(basicOutput, "tileset.json")
-    );
+    const tilesetJsonBuffer = fs.readFileSync(outputFile);
     const tileset = JSON.parse(tilesetJsonBuffer.toString());
     const actualContentUris = await SpecHelpers.collectExplicitContentUris(
       tileset.root
@@ -90,8 +127,96 @@ describe("TilesetMerger", function () {
     actualContentUris.sort();
 
     const expectedContentUris = [
-      "specs/data/mergeTilesets/basicMerge/TilesetA/tileset.json",
-      "specs/data/mergeTilesets/basicMerge/sub/TilesetA/tileset.json",
+      "TilesetA-0/tileset.json",
+      "TilesetA/tileset.json",
+    ];
+    expect(actualContentUris).toEqual(expectedContentUris);
+  });
+
+  it("merges tilesets from directories into a single tileset in a directory for mergeJson", async function () {
+    const inputDirectories = [
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/TilesetA"
+      ),
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/sub/TilesetA"
+      ),
+    ];
+    const outputDirectory = Paths.join(
+      SPECS_DATA_BASE_DIRECTORY,
+      "output/mergeTilesets/basicMerge"
+    );
+    const outputFile = Paths.join(outputDirectory, "tileset.json");
+
+    await TilesetOperations.mergeJson(
+      inputDirectories,
+      outputDirectory,
+      overwrite
+    );
+
+    // Ensure that the output directory contains the expected files:
+    const actualRelativeFiles =
+      SpecHelpers.collectRelativeFileNames(outputDirectory);
+    actualRelativeFiles.sort();
+    const expectedRelativeFiles = ["tileset.json"];
+    expect(actualRelativeFiles).toEqual(expectedRelativeFiles);
+
+    // Ensure that the single 'tileset.json' contains the
+    // proper content URIs for the external tilesets:
+    const tilesetJsonBuffer = fs.readFileSync(outputFile);
+    const tileset = JSON.parse(tilesetJsonBuffer.toString());
+    const actualContentUris = await SpecHelpers.collectExplicitContentUris(
+      tileset.root
+    );
+    actualContentUris.sort();
+
+    const expectedContentUris = [
+      "../../../mergeTilesets/basicMerge/TilesetA/tileset.json",
+      "../../../mergeTilesets/basicMerge/sub/TilesetA/tileset.json",
+    ];
+    expect(actualContentUris).toEqual(expectedContentUris);
+  });
+
+  it("merges tilesets from files into a single tileset file for mergeJson", async function () {
+    const inputFiles = [
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/TilesetA/tileset.json"
+      ),
+      Paths.join(
+        SPECS_DATA_BASE_DIRECTORY,
+        "mergeTilesets/basicMerge/sub/TilesetA/tileset.json"
+      ),
+    ];
+    const outputDirectory = Paths.join(
+      SPECS_DATA_BASE_DIRECTORY,
+      "output/mergeTilesets/basicMerge"
+    );
+    const outputFile = Paths.join(outputDirectory, "tileset.json");
+
+    await TilesetOperations.mergeJson(inputFiles, outputFile, overwrite);
+
+    // Ensure that the output directory contains the expected files:
+    const actualRelativeFiles =
+      SpecHelpers.collectRelativeFileNames(outputDirectory);
+    actualRelativeFiles.sort();
+    const expectedRelativeFiles = ["tileset.json"];
+    expect(actualRelativeFiles).toEqual(expectedRelativeFiles);
+
+    // Ensure that the single 'tileset.json' contains the
+    // proper content URIs for the external tilesets:
+    const tilesetJsonBuffer = fs.readFileSync(outputFile);
+    const tileset = JSON.parse(tilesetJsonBuffer.toString());
+    const actualContentUris = await SpecHelpers.collectExplicitContentUris(
+      tileset.root
+    );
+    actualContentUris.sort();
+
+    const expectedContentUris = [
+      "../../../mergeTilesets/basicMerge/TilesetA/tileset.json",
+      "../../../mergeTilesets/basicMerge/sub/TilesetA/tileset.json",
     ];
     expect(actualContentUris).toEqual(expectedContentUris);
   });

--- a/src/base/base/Paths.ts
+++ b/src/base/base/Paths.ts
@@ -102,6 +102,17 @@ export class Paths {
    * the result uses `/` forward slashes as the directory
    * separator.
    *
+   * Note:
+   * - The first argument is assumed to be a directory
+   * - The second argument is assumed to be a file name
+   * - The result is the relativized file name
+   *
+   * For example: In a call like
+   * `relativize("./example/directoryA", "./example/directoryB/file.txt")`
+   * the second argument has to be the file name, and the result
+   * will be "../directoryB/file.txt", which is the path of the
+   * file _relative to_ the directory that is given as the first argument.
+   *
    * @param directory - The directory
    * @param fileName - The file name
    * @returns The resulting path

--- a/src/tilesets/tilesets/Tilesets.ts
+++ b/src/tilesets/tilesets/Tilesets.ts
@@ -33,6 +33,40 @@ export class Tilesets {
   }
 
   /**
+   * Determine a directory name from the given tileset name.
+   *
+   * When the given name ends with `.json`, `.3tz`, or `.3dtiles`
+   * (case-insensitively), then the directory name of that file
+   * name is returned. Otherwise, the given name is assumed to
+   * be a directory name and returned directly.
+   *
+   * NOTE: This is working around the ambiguity that is related to
+   * https://github.com/CesiumGS/3d-tiles/issues/184 : When someone
+   * uses a path like "./data/target" as a target name, then it is
+   * not clear whether the result should be
+   *
+   * - a JSON file "./data/target" (without extension)
+   * - a file called "./data/target/tileset.json"
+   *
+   * The latter is the default assumption that is used for source
+   * data: When the source is a directory, then it assumes
+   * that there is a 'tileset.json' file in this directory.
+   *
+   * For the target, checking whether there is a file extension
+   * seems to be a reasonable workaround.
+   *
+   * @param tilesetName - The tileset name
+   * @returns The directory name
+   */
+  static determineTilesetDirectoryName(tilesetName: string) {
+    const n = tilesetName.toLowerCase();
+    if (n.endsWith(".json") || n.endsWith(".3tz") || n.endsWith(".3dtiles")) {
+      return path.dirname(tilesetName);
+    }
+    return tilesetName;
+  }
+
+  /**
    * Returns whether the given names likely refer to the same package.
    *
    * This will interpret the given strings as paths and normalize them.


### PR DESCRIPTION
There have been some quirks in the handling of paths for the `merge` and `mergeJson` commands.

Some details are described in the conversation [around a recent PR](https://github.com/CesiumGS/3d-tiles-tools/pull/142#issuecomment-2223397115). An attempt to summarize some of the main points:

- The `merge` command originally copied the (external) source tilesets to the target directory
- It copied the sources into _subdirectories_ of the target directory. The names of these subdirectories have been disambiguated with some not-so-well-thought-through "identifiers"...
- For the `mergeJson` command, these "identifiers" (i.e. subdirectory names) did not make sense. The merged tileset JSON should just _refer_ to the _real_ source tileset JSON files, using relative URIs in the `content.uri`
- The attempt to fix this unveiled some "skeletons in the closet". We had been aware of some of that, but ... maybe in denial about the implications (details below)

This PR changes these aforementioned `tilesetSourceIdentifiers`  to actually be `externalTilesetDirectories`: 

- For the `merge` command, these still are the (disambiguated, but somewhat arbitrary) names of the subdirectories that the sources will be copied to
- For the `mergeJson` command, these are the actual _relative_ directories that will become part of the `content.uri` that refer to the source tilesets

@jo-chemla Maybe you want to give this a try. I tried to cover some of the relevant parts in the specs, differentiating the cases of [`merge`, `mergeJson`] ⨯ [directories, files]. But it could be worthwhile to consider adding "more tricky cases" there.

---

Details:

Most of the 3D Tiles Tools commands can transparently operate on `3tz` or `3dtiles` files, or on the file system. The latter generally allowed inputs and outputs to **either** be given as an explicit file name like `"./example/tileset.json"`, **or** as a directory name like `"./example"`, and then make the assumption that this directory contains a file called `tileset.json`. This is a leftover from https://github.com/CesiumGS/3d-tiles/issues/184 . It becomes more tricky due to the fact that in `3tz` and `3dtiles` files, there **is** a requirement for the top-level tileset JSON to be called `tileset.json`. And conversely, when someone gives something like `./output` as the target, it is by no means clear whether this should be a JSON file without an extension, or whether the output should be `./output/tileset.json` 😬 I tried to sort some of that out, using [20 lines of comments for a 5 line function](https://github.com/CesiumGS/3d-tiles-tools/commit/c1af3e1777ca5de548c03f57eee32b75517cd1ef) ...

