### PR TITLE
Decode 3D texture coordinates during upgrade

### DIFF
--- a/src/tools/migration/TileFormatsMigrationB3dm.ts
+++ b/src/tools/migration/TileFormatsMigrationB3dm.ts
@@ -90,8 +90,10 @@ export class TileFormatsMigrationB3dm {
               primitive,
               batchIdToFeatureIdAccessor
             );
-          if (propertyTable) {
-            featureId.setPropertyTable(propertyTable);
+          if (featureId) {
+            if (propertyTable) {
+              featureId.setPropertyTable(propertyTable);
+            }
           }
         }
       }

--- a/src/tools/migration/TileTableDataToMeshFeatures.ts
+++ b/src/tools/migration/TileTableDataToMeshFeatures.ts
@@ -23,7 +23,7 @@ export class TileTableDataToMeshFeatures {
    * extension that is associated with this primitive, storing
    * the former batch ID attribute as a new `_FEATURE_ID_0` attribute.
    *
-   * Note that this will remove the former batch ID attributes
+   * Note that this will set the former batch ID attributes
    * in the given primitive to `null`, but it will not dispose
    * the corresponding accessors. These have to be disposed
    * after all primitives have been processed.
@@ -42,7 +42,7 @@ export class TileTableDataToMeshFeatures {
     document: Document,
     primitive: Primitive,
     batchIdToFeatureIdAccessor: Map<Accessor, Accessor>
-  ): FeatureId {
+  ): FeatureId | undefined {
     let batchIdAttribute = primitive.getAttribute("_BATCHID");
     if (!batchIdAttribute) {
       batchIdAttribute = primitive.getAttribute("BATCHID");
@@ -52,9 +52,12 @@ export class TileTableDataToMeshFeatures {
             "should be _BATCHID, starting with an underscore"
         );
       } else {
-        throw new TileFormatError(
-          "The primitive did not contain a _BATCHID attribute"
-        );
+        // XXX Preliminarily ignore this
+        //throw new TileFormatError(
+        //  "The primitive did not contain a _BATCHID attribute"
+        //);
+        logger.warn("The primitive did not contain a _BATCHID attribute");
+        return undefined;
       }
     }
 


### PR DESCRIPTION
This is structurally similar to https://github.com/CesiumGS/3d-tiles-tools/pull/98 (where "structurally similar" means "largely copy and paste"), with a similar summary: 

- glTF 1.0 (in B3DM or I3DM) could contain 3D (!) texture coordinates stored as `SHORT`
- in glTF 1.0, these had been decoded in the shader (that was part of glTF 1.0)
- When upgrading glTF 1.0 to glTF 2.0 with gltf-pipeline, then the 3D texture coordinates are transferred to the glTF 2.0
- This caused an invalid asset (e.g. with rendering errors in CesiumJS)

The exact encoding of the texture coordinates is not yet clear. It just seems to be "one (arbitrary) way" of not storing the `VEC2/FLOAT` (2 * 4 = 8 bytes), but instead, storing `VEC3/SHORT` (3 * 2 = 6 bytes).

In one of the relevant glTF files, the decoding in the shader was done like this:
```
const float uvMultiplier = 0.0000305185; // 1/32767
v_texcoord0 = a_texcoord0.xy * uvMultiplier * (a_texcoord0.z+32767.0);
```
This was for an accessor with VEC3/SHORT.

This PR implements the decoding of VEC3/SHORT (or VEC3/BYTE) texture coordinates into VEC2/FLOAT texture coordinates. From a quick test with one of these B3DM files that contain such glTF 1.0 data, the result can be rendered in CesiumJS.

**But...** there are some guesses and degrees of freedom.

- Is the encoding always implemented like this? 
- Does this have a _name_ (like "oct-encoded" for normals)? 
- Should this also cover the case of `UNSIGNED_SHORT` components? 
- ...

Some of this still has to be sorted out and confirmed, so I'll just open this a a DRAFT for now.

---

(NOTE: The state in this PR currently tries to ignore missing `BATCHID` attributes in B3DM files. This should not be necessary. In the final state, this might be omitted. But there are reasons to assume that this is one quirk that may happen for ~"some old legacy data sets" - details TBD)




