### PR TITLE
Handle missing batch ID attributes

### DIFF
--- a/src/tools/migration/TileFormatsMigrationB3dm.ts
+++ b/src/tools/migration/TileFormatsMigrationB3dm.ts
@@ -90,7 +90,7 @@ export class TileFormatsMigrationB3dm {
               primitive,
               batchIdToFeatureIdAccessor
             );
-          if (propertyTable) {
+          if (featureId && propertyTable) {
             featureId.setPropertyTable(propertyTable);
           }
         }

--- a/src/tools/migration/TileTableDataToMeshFeatures.ts
+++ b/src/tools/migration/TileTableDataToMeshFeatures.ts
@@ -23,10 +23,14 @@ export class TileTableDataToMeshFeatures {
    * extension that is associated with this primitive, storing
    * the former batch ID attribute as a new `_FEATURE_ID_0` attribute.
    *
-   * Note that this will remove the former batch ID attributes
+   * Note that this will set the former batch ID attributes
    * in the given primitive to `null`, but it will not dispose
    * the corresponding accessors. These have to be disposed
    * after all primitives have been processed.
+   *
+   * If the given primitive does not contain a batch ID attribute,
+   * then a warning will be printed, and `undefined` will be
+   * returned.
    *
    * @param document - The glTF-Transform document
    * @param primitive - The glTF-Transform primitive
@@ -42,7 +46,7 @@ export class TileTableDataToMeshFeatures {
     document: Document,
     primitive: Primitive,
     batchIdToFeatureIdAccessor: Map<Accessor, Accessor>
-  ): FeatureId {
+  ): FeatureId | undefined {
     let batchIdAttribute = primitive.getAttribute("_BATCHID");
     if (!batchIdAttribute) {
       batchIdAttribute = primitive.getAttribute("BATCHID");
@@ -52,9 +56,10 @@ export class TileTableDataToMeshFeatures {
             "should be _BATCHID, starting with an underscore"
         );
       } else {
-        throw new TileFormatError(
-          "The primitive did not contain a _BATCHID attribute"
+        logger.warn(
+          "The primitive did not contain a _BATCHID or BATCHID attribute"
         );
+        return undefined;
       }
     }
 


### PR DESCRIPTION
(This was originally causally thrown into https://github.com/CesiumGS/3d-tiles-tools/pull/146 , but should be a dedicated PR:) 

When running the upgrade with `targetVersion 1.1`, then the tools will try to convert B3DM to GLB. The batch table from the B3DM is converted into glTF extensions (`EXT_mesh_features` and `EXT_structural_metadata`). 

But apparently, there are some _very_ old/legacy B3DM files that define a batch table, but contain glTF 1.0 that do not define a `BATCHID` or `_BATCHID` attribute. From a quick (somewhat shallow) inspection, it looks like the batch ID might somehow have been defined programmatically via the shader that was stored in the glTF 1.0. There is no data available that has such a missing batch ID and is known to be "valid". So any attempt to migrate this to new structures (to emulate the old behavior) would involve lots of guesses and/or code archeology.

Therefore, this PR handles this case in the most simple form: When such a B3DM with a glTF 1.0 without batch IDs is encuntered during the upgrade to 1.1, then it will print a warning, and the resulting GLB will _not_ contain `EXT_mesh_features`. 
