### PR TITLE
Minor fix to throw error when it should be thrown

### DIFF
--- a/specs/metadata/metadata/ArrayValuesSpec.ts
+++ b/specs/metadata/metadata/ArrayValuesSpec.ts
@@ -632,4 +632,23 @@ describe("metadata/ArrayValues", function () {
     const actual = ArrayValues.anyDeepGreaterThan(a, b);
     expect(actual).toEqual(expected);
   });
+
+  //==========================================================================
+  // Error cases for deepMin/deepMax
+
+  it("throws error for non-numeric types in deepMin", function () {
+    expect(function () {
+      const a = [5, 2];
+      const b = [3, "NOT_A_NUMBER"];
+      ArrayValues.deepMin(a, b);
+    }).toThrowError();
+  });
+
+  it("throws error for non-numeric types in deepMax", function () {
+    expect(function () {
+      const a = [5, 2];
+      const b = [3, "NOT_A_NUMBER"];
+      ArrayValues.deepMax(a, b);
+    }).toThrowError();
+  });
 });

--- a/src/metadata/metadata/ArrayValues.ts
+++ b/src/metadata/metadata/ArrayValues.ts
@@ -43,7 +43,7 @@ export class ArrayValues {
   // Implementation note:
   // The methods here are supposed to be called in a context
   // where no (compile-time) type information is available.
-  // Thes are offered to operate on "any" types, but usually
+  // These are offered to operate on "any" types, but usually
   // delegate to "...Internal" methods with more specific
   // type signatures. This does not imply any compile-time
   // checks, but these specific signatures might be exposed
@@ -63,7 +63,7 @@ export class ArrayValues {
     if (typeof value === "bigint") {
       return true;
     }
-    return true;
+    return false;
   }
 
   /**


### PR DESCRIPTION
Just something that I stumbled over: Certain functions did _not_ throw an error when they should have, because of a `return true` that should have been `return false` deeeeply in one of the internal functions.
(Added a test case for that as well)
