### PR TITLE
Update `better-sqlite3` version to 11.5.0 for Node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@gltf-transform/extensions": "^3.9.0",
     "@gltf-transform/functions": "^3.9.0",
     "archiver": "^5.3.1",
-    "better-sqlite3": "^8.0.1",
+    "better-sqlite3": "^11.5.0",
     "cesium": "^1.103.0",
     "draco3d": "^1.5.6",
     "draco3dgltf": "^1.5.6",


### PR DESCRIPTION
The previous version (8.0.1) was not compatible with Node 22.

I tested the current state with Node 16.16.0 (which is actually lower than what CesiumJS needs) and 22.11.0, and both worked.

