### PR TITLE
Avoid null as return type

### DIFF
--- a/specs/base/contentTypes/LazyContentDataSpec.ts
+++ b/specs/base/contentTypes/LazyContentDataSpec.ts
@@ -8,14 +8,14 @@ function createTestResourceResolver(): ResourceResolver {
     resolveUri(uri: string) {
       return uri;
     },
-    async resolveData(uri: string): Promise<Buffer | null> {
-      return null;
+    async resolveData(uri: string): Promise<Buffer | undefined> {
+      return undefined;
     },
     async resolveDataPartial(
       uri: string,
       maxBytes: number
-    ): Promise<Buffer | null> {
-      return null;
+    ): Promise<Buffer | undefined> {
+      return undefined;
     },
     derive(uri: string): ResourceResolver {
       return this;

--- a/src/base/contentTypes/BufferedContentData.ts
+++ b/src/base/contentTypes/BufferedContentData.ts
@@ -32,7 +32,7 @@ export class BufferedContentData implements ContentData {
    * @returns The ContentData
    */
   static create(uri: string): ContentData {
-    let data: Buffer | null = null;
+    let data: Buffer | undefined = undefined;
     try {
       data = fs.readFileSync(uri);
     } catch (error) {
@@ -61,10 +61,10 @@ export class BufferedContentData implements ContentData {
   private readonly _magic: Buffer;
 
   /**
-   * The content data, or `null` if the data could not
+   * The content data, or `undefined` if the data could not
    * be resolved.
    */
-  private readonly _data: Buffer | null;
+  private readonly _data: Buffer | undefined;
 
   /**
    * The object that was parsed from the content, assuming
@@ -86,7 +86,7 @@ export class BufferedContentData implements ContentData {
    * @param uri - The URI of the content data
    * @param data - The actual content data buffer
    */
-  constructor(uri: string, data: Buffer | null) {
+  constructor(uri: string, data: Buffer | undefined) {
     this._uri = uri;
     this._extension = path.extname(uri).toLowerCase();
     if (data) {
@@ -112,7 +112,7 @@ export class BufferedContentData implements ContentData {
 
   /** {@inheritDoc ContentData.exists} */
   async exists(): Promise<boolean> {
-    return this._data !== null;
+    return this._data !== undefined;
   }
 
   /** {@inheritDoc ContentData.magic} */
@@ -121,7 +121,7 @@ export class BufferedContentData implements ContentData {
   }
 
   /** {@inheritDoc ContentData.data} */
-  async getData(): Promise<Buffer | null> {
+  async getData(): Promise<Buffer | undefined> {
     return this._data;
   }
 

--- a/src/base/contentTypes/ContentData.ts
+++ b/src/base/contentTypes/ContentData.ts
@@ -36,10 +36,10 @@ export interface ContentData {
   /**
    * Returns the actual content data that was read from the URI.
    *
-   * @returns The promise to the data, or to `null` when the
+   * @returns The promise to the data, or to `undefined` when the
    * data could not be obtained.
    */
-  getData(): Promise<Buffer | null>;
+  getData(): Promise<Buffer | undefined>;
 
   /**
    * Returns the object that was parsed from the content data,

--- a/src/base/contentTypes/LazyContentData.ts
+++ b/src/base/contentTypes/LazyContentData.ts
@@ -50,10 +50,10 @@ export class LazyContentData implements ContentData {
   private _magic: Buffer | undefined;
 
   /**
-   * The content data, or `null` if the data could not
+   * The content data, or `undefined` if the data could not
    * be resolved.
    */
-  private _data: Buffer | null;
+  private _data: Buffer | undefined;
 
   /**
    * Whether the `_data` was already requested
@@ -87,7 +87,7 @@ export class LazyContentData implements ContentData {
     this._resourceResolver = resourceResolver;
     this._extension = path.extname(uri).toLowerCase();
     this._magic = undefined;
-    this._data = null;
+    this._data = undefined;
     this._dataWasRequested = false;
     this._parsedObject = undefined;
     this._parsedObjectWasRequested = false;
@@ -112,7 +112,7 @@ export class LazyContentData implements ContentData {
       this._uri,
       1
     );
-    this._exists = partialData !== null;
+    this._exists = partialData !== undefined;
     return this._exists;
   }
 
@@ -137,13 +137,13 @@ export class LazyContentData implements ContentData {
   }
 
   /** {@inheritDoc ContentData.getData} */
-  async getData(): Promise<Buffer | null> {
+  async getData(): Promise<Buffer | undefined> {
     if (this._dataWasRequested) {
       return this._data;
     }
     this._data = await this._resourceResolver.resolveData(this._uri);
     this._dataWasRequested = true;
-    this._exists = this._data !== null;
+    this._exists = this._data !== undefined;
     return this._data;
   }
 

--- a/src/base/io/FileResourceResolver.ts
+++ b/src/base/io/FileResourceResolver.ts
@@ -28,13 +28,13 @@ export class FileResourceResolver implements ResourceResolver {
   async resolveDataPartial(
     uri: string,
     maxBytes: number
-  ): Promise<Buffer | null> {
+  ): Promise<Buffer | undefined> {
     if (Uris.isDataUri(uri)) {
       const data = Buffer.from(uri.split(",")[1], "base64");
       return data;
     }
     if (Uris.isAbsoluteUri(uri)) {
-      return null;
+      return undefined;
     }
     const resolved = this.resolveUri(uri);
     try {
@@ -44,22 +44,22 @@ export class FileResourceResolver implements ResourceResolver {
       fs.closeSync(fd);
       return buffer;
     } catch (error) {
-      return null;
+      return undefined;
     }
   }
 
   /** {@inheritDoc ResourceResolver.resolveData} */
-  async resolveData(uri: string): Promise<Buffer | null> {
+  async resolveData(uri: string): Promise<Buffer | undefined> {
     if (Uris.isDataUri(uri)) {
       const data = Buffer.from(uri.split(",")[1], "base64");
       return data;
     }
     if (Uris.isAbsoluteUri(uri)) {
-      return null;
+      return undefined;
     }
     const resolved = this.resolveUri(uri);
     if (!fs.existsSync(resolved)) {
-      return null;
+      return undefined;
     }
     const data = fs.readFileSync(resolved);
     // See https://github.com/nodejs/node/issues/35351

--- a/src/base/io/ResourceResolver.ts
+++ b/src/base/io/ResourceResolver.ts
@@ -27,9 +27,9 @@ export interface ResourceResolver {
    *
    * @param uri - The URI
    * @returns A promise that resolves with the buffer data,
-   * or with `null` if the resource could not be resolved.
+   * or with `undefined` if the resource could not be resolved.
    */
-  resolveData(uri: string): Promise<Buffer | null>;
+  resolveData(uri: string): Promise<Buffer | undefined>;
 
   /**
    * Resolve parts of the data from the given URI.
@@ -37,7 +37,7 @@ export interface ResourceResolver {
    * The given URI may be relative to the base URI for
    * which this instance has been created.
    *
-   * If the resource cannot be resolved, then `null` is
+   * If the resource cannot be resolved, then `undefined` is
    * returned.
    *
    * Otherwise, the returned buffer contains _at least_ the
@@ -46,9 +46,12 @@ export interface ResourceResolver {
    *
    * @param uri - The URI
    * @returns A promise that resolves with the buffer data,
-   * or with `null` if the resource could not be resolved.
+   * or with `undefined` if the resource could not be resolved.
    */
-  resolveDataPartial(uri: string, maxBytes: number): Promise<Buffer | null>;
+  resolveDataPartial(
+    uri: string,
+    maxBytes: number
+  ): Promise<Buffer | undefined>;
 
   /**
    * Derive an instance from this one, with a different base

--- a/src/base/io/UnzippingResourceResolver.ts
+++ b/src/base/io/UnzippingResourceResolver.ts
@@ -23,10 +23,10 @@ export class UnzippingResourceResolver implements ResourceResolver {
   }
 
   /** {@inheritDoc ResourceResolver.resolveData} */
-  async resolveData(uri: string): Promise<Buffer | null> {
+  async resolveData(uri: string): Promise<Buffer | undefined> {
     const delegateData = await this._delegate.resolveData(uri);
-    if (delegateData === null) {
-      return null;
+    if (delegateData === undefined) {
+      return undefined;
     }
     const isGzipped = Buffers.isGzipped(delegateData);
     if (!isGzipped) {
@@ -40,21 +40,21 @@ export class UnzippingResourceResolver implements ResourceResolver {
   async resolveDataPartial(
     uri: string,
     maxBytes: number
-  ): Promise<Buffer | null> {
+  ): Promise<Buffer | undefined> {
     const partialDelegateData = await this._delegate.resolveDataPartial(
       uri,
       maxBytes
     );
-    if (partialDelegateData === null) {
-      return null;
+    if (partialDelegateData === undefined) {
+      return undefined;
     }
     const isGzipped = Buffers.isGzipped(partialDelegateData);
     if (!isGzipped) {
       return partialDelegateData;
     }
     const fullDelegateData = await this._delegate.resolveData(uri);
-    if (fullDelegateData === null) {
-      return null;
+    if (fullDelegateData === undefined) {
+      return undefined;
     }
     const data = zlib.gunzipSync(fullDelegateData);
     return data;

--- a/src/base/spatial/OctreeCoordinates.ts
+++ b/src/base/spatial/OctreeCoordinates.ts
@@ -38,9 +38,9 @@ export class OctreeCoordinates implements TreeCoordinates {
   }
 
   /** {@inheritDoc TreeCoordinates.parent} */
-  parent(): OctreeCoordinates | null {
+  parent(): OctreeCoordinates | undefined {
     if (this._level === 0) {
-      return null;
+      return undefined;
     }
     const pLevel = this._level - 1;
     const px = this._x >> 1;

--- a/src/base/spatial/QuadtreeCoordinates.ts
+++ b/src/base/spatial/QuadtreeCoordinates.ts
@@ -32,9 +32,9 @@ export class QuadtreeCoordinates implements TreeCoordinates {
   }
 
   /** {@inheritDoc TreeCoordinates.parent} */
-  parent(): QuadtreeCoordinates | null {
+  parent(): QuadtreeCoordinates | undefined {
     if (this._level === 0) {
-      return null;
+      return undefined;
     }
     const pLevel = this._level - 1;
     const px = this._x >> 1;

--- a/src/base/spatial/TreeCoordinates.ts
+++ b/src/base/spatial/TreeCoordinates.ts
@@ -14,11 +14,11 @@ export interface TreeCoordinates {
 
   /**
    * Returns the parent coordinates of these coordinates,
-   * or `null` if this is the root.
+   * or `undefined` if this is the root.
    *
    * @returns The parent coordinates
    */
-  parent(): TreeCoordinates | null;
+  parent(): TreeCoordinates | undefined;
 
   /**
    * Returns a generator for the child coordinates of these coordinates

--- a/src/tilesets/tilesetData/TilesetSourceFs.ts
+++ b/src/tilesets/tilesetData/TilesetSourceFs.ts
@@ -60,11 +60,12 @@ export class TilesetSourceFs implements TilesetSource {
     if (!fs.existsSync(fullFileName)) {
       return undefined;
     }
-    const data = fs.readFileSync(fullFileName);
-    if (data === null) {
+    try {
+      const data = fs.readFileSync(fullFileName);
+      return data;
+    } catch (error) {
       return undefined;
     }
-    return data;
   }
 
   /** {@inheritDoc TilesetSource.close} */

--- a/src/tilesets/tilesetData/TilesetSourceResourceResolver.ts
+++ b/src/tilesets/tilesetData/TilesetSourceResourceResolver.ts
@@ -25,7 +25,7 @@ export class TilesetSourceResourceResolver implements ResourceResolver {
   }
 
   /** {@inheritDoc ResourceResolver.resolveData} */
-  async resolveData(uri: string): Promise<Buffer | null> {
+  async resolveData(uri: string): Promise<Buffer | undefined> {
     return this.resolveDataInternal(uri);
   }
 
@@ -33,26 +33,26 @@ export class TilesetSourceResourceResolver implements ResourceResolver {
   async resolveDataPartial(
     uri: string,
     maxBytes: number
-  ): Promise<Buffer | null> {
+  ): Promise<Buffer | undefined> {
     const buffer = await this.resolveDataInternal(uri);
     if (!buffer) {
-      return null;
+      return undefined;
     }
     return buffer.subarray(0, maxBytes);
   }
 
-  private async resolveDataInternal(uri: string): Promise<Buffer | null> {
+  private async resolveDataInternal(uri: string): Promise<Buffer | undefined> {
     if (Uris.isDataUri(uri)) {
       const data = Buffer.from(uri.split(",")[1], "base64");
       return data;
     }
     if (Uris.isAbsoluteUri(uri)) {
-      return null;
+      return undefined;
     }
     const localUri = this.resolveUri(uri);
     const value = await this._tilesetSource.getValue(localUri);
     if (!value) {
-      return null;
+      return undefined;
     }
     return value;
   }


### PR DESCRIPTION
Addresses https://github.com/CesiumGS/3d-tiles-tools/issues/162

Builds upon https://github.com/CesiumGS/3d-tiles-tools/pull/167 - will be processed further after this one is merged.

There have been a few places that used `null` as a return type. While there are possible justifications for that, it was hard to ensure consistency in that regard (and it seems to be pretty uncommon in other codebases like CesiumJS). This PR changes the use of these `null` values to `undefined`.

The affected places:

- `ResourceResolver.resolve...` functions returned `null` when the data could not be resolved, but return `undefined` now
- `ContentData.getData` (which usually contained the data that was obtained with a `ResourceResolver`) could be `null`, and can now be `undefined` accordingly
- The `TreeCoordinates` interface returned `null` as the `parent` of root nodes. This also returns `undefined` now

(The other changes are the respective implementations and places where these values had been used)

---

*Note:* There is still a large part of the codebase that _does_ use `null` - namely, the implementations of the glTF extensions based on glTF-Transform. This is because glTF-Transform internally _does_ use `null`, pretty consistently. So it makes sense to use `null` in these implementations as well. 
