### PR TITLE
Update demos for async API

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,3 @@ dist
 etc
 generateThirdParty.js
 src/ktx/ktx/external/basis_encoder.cjs
-demos

--- a/demos/.eslintrc.json
+++ b/demos/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "project": "./demos/tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "root": true,
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-floating-promises": "error"
+  }
+}

--- a/demos/metadata/MetadataDemos.ts
+++ b/demos/metadata/MetadataDemos.ts
@@ -126,7 +126,7 @@ function createValueString(value: any) {
  * Prints all properties of the `TilesetWithFullMetadata` sample
  * data, as they are obtained via a `MetadataEntityModel`.
  */
-async function testTilesetWithFullMetadata() {
+function testTilesetWithFullMetadata() {
   // Note: This is making some assumptions about
   // the input, and only intended for the basic
   // demo of the `MetadataEntityModels` class

--- a/demos/tilesets/benchmarks/PackageCreationBenchmark.ts
+++ b/demos/tilesets/benchmarks/PackageCreationBenchmark.ts
@@ -26,15 +26,15 @@ async function fillTilesetTarget(
   configString: string
 ) {
   const beforeMs = performance.now();
-  tilesetTarget.begin(fullOutputFileName, true);
-  tilesetTarget.addEntry(
+  await tilesetTarget.begin(fullOutputFileName, true);
+  await tilesetTarget.addEntry(
     "tileset.json",
     BenchmarkUtils.createDummyTilesetJsonBuffer()
   );
   for (const entry of entries) {
     const key = entry.key;
     const content = entry.value;
-    tilesetTarget.addEntry(key, content);
+    await tilesetTarget.addEntry(key, content);
   }
   await tilesetTarget.end();
   const afterMs = performance.now();
@@ -81,4 +81,4 @@ async function run() {
   console.log("Running test DONE");
 }
 
-run();
+void run();

--- a/demos/tilesets/benchmarks/PackageReadingBenchmark.ts
+++ b/demos/tilesets/benchmarks/PackageReadingBenchmark.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import util from "util";
 import { performance } from "perf_hooks";
 
+import { Iterables } from "3d-tiles-tools";
 import { TilesetSource } from "3d-tiles-tools";
 import { TilesetSource3tz } from "3d-tiles-tools";
 import { TilesetSource3dtiles } from "3d-tiles-tools";
@@ -18,15 +19,15 @@ import { Arrays } from "./Arrays";
  * @param configString A string describing the configuration
  * of the benchmark, only used for logging
  */
-function readTilesetSource(
+async function readTilesetSource(
   tilesetSource: TilesetSource,
   fullInputFileName: string,
   configString: string
 ) {
   let beforeMs = 0;
-  tilesetSource.open(fullInputFileName);
+  await tilesetSource.open(fullInputFileName);
 
-  const keys = [...tilesetSource.getKeys()];
+  const keys = await Iterables.asyncToArray(await tilesetSource.getKeys());
 
   let totalBytes = 0;
   const passes = 5;
@@ -37,14 +38,14 @@ function readTilesetSource(
       totalBytes = 0;
     }
     for (const key of keys) {
-      const content = tilesetSource.getValue(key);
+      const content = await tilesetSource.getValue(key);
       if (content) {
         totalBytes += content.length;
       }
     }
     Arrays.shuffle(keys, "0");
   }
-  tilesetSource.close();
+  await tilesetSource.close();
   const afterMs = performance.now();
   const durationMs = afterMs - beforeMs;
   const message = util.format(
@@ -72,14 +73,14 @@ async function run() {
     const inputFilePrefix = inputDirectory + configString;
 
     const tilesetSource3tz = new TilesetSource3tz();
-    readTilesetSource(
+    await readTilesetSource(
       tilesetSource3tz,
       inputFilePrefix + ".3tz",
       "3TZ     " + configString
     );
 
     const tilesetSource3dtiles = new TilesetSource3dtiles();
-    readTilesetSource(
+    await readTilesetSource(
       tilesetSource3dtiles,
       inputFilePrefix + ".3dtiles",
       "3DTILES " + configString
@@ -89,4 +90,4 @@ async function run() {
   console.log("Running test DONE");
 }
 
-run();
+void run();

--- a/demos/tsconfig.json
+++ b/demos/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2021",
+    "baseUrl": "./",
+    "strict": true,
+    "lib": ["es2021"],
+
+    "outDir": "./build",
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strictNullChecks": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": false,
+    "sourceMap": true,
+  },
+  "include": ["**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
A follow-up for https://github.com/CesiumGS/3d-tiles-tools/pull/167 : Most of the demos in the `demos` project had already been updated to use the new `async` API for the `TilesetSource`/`TilesetTarget`. But some of the "benchmark" demos had not been updated yet. They are updated here, and the `demos` project receives its own `tsconfig` and `eslintrc` (the latter with `no-floating-promises: error`) to detect this by default when running the linting.

