### PR TITLE
Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,15 +312,16 @@ Additional command line options:
 | Flag | Description | Required |
 | ---- | ----------- | -------- |
 |`--cartographicPositionDegrees`|An array of either two or three values, which are the (longitude, latitude) or (longitude, latitude, height) of the target position. The longitude and latitude are given in degrees, and the height is given in meters.| No |
+|`--rotationDegrees`|An array of three values, which are the (heading, pitch, roll) rotation at the target position, in degrees.| No |
 
 If the input is a single file, then this will result in a single (root) tile with the input file as its tile content. If the input is a directory, then all content files in this directory will be used as tile content, recursively. The exact set of file types that are considered to be 'tile content' is not specified, but it will include GLB, B3DM, PNTS, I3DM, and CMPT files.
 
 Examples:
 
 ```
-npx 3d-tiles-tools createTilesetJson -i ./input/ -o ./output/tileset.json --cartographicPositionDegrees -75.152 39.94 10
+npx 3d-tiles-tools createTilesetJson -i ./input/ -o ./output/tileset.json --cartographicPositionDegrees -75.152 39.94 10 --rotationDegrees 45 0 0
 ```
-This creates the specified tileset JSON file, which will refer to all tile content files in the given input directory as its tile contents. The root node of the tileset will have a transform that will place it at the given cartographic position.
+This creates the specified tileset JSON file, which will refer to all tile content files in the given input directory as its tile contents. The root node of the tileset will have a transform that will place it at the given cartographic position, with the specified rotation.
 
 
 

--- a/src/cli/ToolsMain.ts
+++ b/src/cli/ToolsMain.ts
@@ -632,7 +632,7 @@ export class ToolsMain {
     ) {
       logger.info(
         `Creating tileset at cartographic position: ` +
-          `${cartographicPositionDegrees} (in degress) and rotation: ` +
+          `${cartographicPositionDegrees} (in degrees) and rotation: ` +
           `${rotationDegrees} (in degrees)`
       );
       const transform =
@@ -644,7 +644,7 @@ export class ToolsMain {
     } else if (cartographicPositionDegrees !== undefined) {
       logger.info(
         `Creating tileset at cartographic position: ` +
-          `${cartographicPositionDegrees} (in degress)`
+          `${cartographicPositionDegrees} (in degrees)`
       );
       const transform =
         TilesetJsonCreator.computeTransformFromCartographicPositionDegrees(


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles-tools/issues/182

This **only** fixes documentation (comments and README), so I'll self-merge for now.

The deprecation of `defaultValue` that was mentioned in the issue only affected `gltf-pipeline`, so this is tracked in https://github.com/CesiumGS/gltf-pipeline/pull/672 