### PR TITLE
Use default offset types for strings and arrays

### DIFF
--- a/src/tools/gltfExtensionsUtils/StructuralMetadataUtils.ts
+++ b/src/tools/gltfExtensionsUtils/StructuralMetadataUtils.ts
@@ -154,14 +154,16 @@ export class StructuralMetadataUtils {
     if (arrayOffsets) {
       arrayOffsetsBufferViewData = Buffer.from(arrayOffsets);
     }
-    const arrayOffsetType = propertyTableProperty.getArrayOffsetType();
+    const arrayOffsetType =
+      propertyTableProperty.getArrayOffsetType() ?? "UINT32";
 
     const stringOffsets = propertyTableProperty.getStringOffsets();
     let stringOffsetsBufferViewData: Buffer | undefined;
     if (stringOffsets) {
       stringOffsetsBufferViewData = Buffer.from(stringOffsets);
     }
-    const stringOffsetType = propertyTableProperty.getStringOffsetType();
+    const stringOffsetType =
+      propertyTableProperty.getStringOffsetType() ?? "UINT32";
 
     let enumValueType: string | undefined = undefined;
     const enumType = classProperty.getEnumType();


### PR DESCRIPTION
A minor fix for one of the internal classes: There are utilits functions to create elaborate string representations of all the metadata that is contained in a glTF. At some point, these did not properly fall back to the default of `UINT32` for the string- and array offset types. This could lead to a `null`-access.

