### PR TITLE
Prepare release 0.5.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 0.5.3 - 2026-03-15
+
+- Added export declarations for the new classes that have been introduced in 0.5.2
+
 ### 0.5.2 - 2026-03-15
 
 - Generalized the functionalities that are related to bounding volumes. This includes the introduction of a `VertexProcessing` class that can be used for processing all vertices of tile content to either compute a bounding volume, or to check whether the vertices are contained in a bounding volume, using the newly introduced `BoundingVolumesContainment` class. This is an internal change, only supposed to be used by the 3D Tiles Validator, to perform bounding volume containment validation. See [#189](https://github.com/CesiumGS/3d-tiles-tools/pull/189)

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -69,8 +69,11 @@ After extracting the API definition files, `api-documenter` is used to generate 
       - Build (compile TypeScript to JavaScript)
       - Run the unit tests
       - Generate the documentation
+      - Extract the API definition files
       - Update the third-party information
     - Package the build output folder into a TAR file
+
+- Ensure that any new classes are properly exported in the `/etc/3d-tiles-tools.api.md` file
 
 - Verify the contents of the resulting TAR file. If there are unwanted files, add these files to `.npmignore` and re-generate the tarball
 

--- a/etc/3d-tiles-tools.api.md
+++ b/etc/3d-tiles-tools.api.md
@@ -377,6 +377,15 @@ export interface BoundingVolumeS2 extends RootProperty {
 }
 
 // @internal
+export class BoundingVolumesContainment {
+    static boxContains(box: number[], point: number[], epsilon: number): boolean;
+    static contains(boundingVolume: BoundingVolume, point: number[], epsilon: number): boolean;
+    static longitudeRangeContainsInclusive(westRad: number, eastRad: number, pointRad: number, epsilon: number): boolean;
+    static regionContains(region: number[], point: number[], epsilon: number): boolean;
+    static sphereContains(sphere: number[], point: number[], epsilon: number): boolean;
+}
+
+// @internal
 export class BufferAvailabilityInfo implements AvailabilityInfo {
     constructor(buffer: Buffer, length: number);
     isAvailable(index: number): boolean;
@@ -3240,6 +3249,11 @@ export class VecMath {
     static matrix4ToQuaternion(matrix4Packed: number[]): number[];
     static multiplyAll4(matrices4Packed: number[][]): number[];
     static subtract(a: number[], b: number[], result?: number[]): number[];
+}
+
+// @internal
+export class VertexProcessing {
+    static fromContent(contentUri: string, data: Buffer, externalGlbResolver: (glbUri: string) => Promise<Buffer | undefined>, processInstancePoints: boolean, consumer: (p: number[]) => void): Promise<void>;
 }
 
 // @internal (undocumented)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3d-tiles-tools",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "Apache-2.0",
   "description": "3D Tiles tools",
   "author": {

--- a/src/tools/contentProcessing/VertexProcessing.ts
+++ b/src/tools/contentProcessing/VertexProcessing.ts
@@ -382,8 +382,8 @@ export class VertexProcessing {
    * transform of the respective node, and pass that transformed
    * position to the given consumer.
    *
-   * @param root The root scene or note of the glTF
-   * @param consumer The consumer that will receive the points as 3-element arrays
+   * @param root - The root scene or note of the glTF
+   * @param consumer - The consumer that will receive the points as 3-element arrays
    */
   private static fromGltfNode(
     root: Node | Scene,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,7 @@ export * from "./contentProcessing/GltfPipelineLegacy";
 export * from "./contentProcessing/GltfTransform";
 export * from "./contentProcessing/GltfTransformTextures";
 export * from "./contentProcessing/GltfUtilities";
+export * from "./contentProcessing/VertexProcessing";
 
 export * from "./draco/AttributeInfo";
 export * from "./draco/ComponentDataType";
@@ -48,6 +49,7 @@ export * from "./migration/TypeDetection";
 
 export * from "./tilesetProcessing/BasicTilesetProcessor";
 export * from "./tilesetProcessing/BoundingVolumes";
+export * from "./tilesetProcessing/BoundingVolumesContainment";
 export * from "./tilesetProcessing/TileContentProcessing";
 export * from "./tilesetProcessing/TileContentProcessor";
 export * from "./tilesetProcessing/TileContentProcessors";

--- a/src/tools/tilesetProcessing/BoundingVolumesContainment.ts
+++ b/src/tools/tilesetProcessing/BoundingVolumesContainment.ts
@@ -11,6 +11,8 @@ const logger = Loggers.get("tilesetProcessing");
 
 /**
  * A class offering methods for containment checks of bounding volumes
+ *
+ * @internal
  */
 export class BoundingVolumesContainment {
   // Scratch variable for all containment methods
@@ -35,6 +37,8 @@ export class BoundingVolumesContainment {
    * @param point - The point, as a 3-element array
    * @param epsilon - The absolute epsilon
    * @returns Whether the box contains the point
+   *
+   * @internal
    */
   static contains(
     boundingVolume: BoundingVolume,


### PR DESCRIPTION
The previous release (0.5.2, published a few minutes ago) did not properly export the newly introduced classes that are required by the validator. This was _not_ caught when using this version as a local (file) dependency in the validator. This PR prepares a "patch release" with these classes (hopefully) being exported properly. The release process description in IMPLEMENTATION.md has been updaded to include the step to _explicitly_ check for proper exports, to prevent this from happening again.

- Update version number in package JSON to 0.5.3
- Update auto-generated files
  - Including the newly exported classes in the API definition
- Update release process description in IMPLEMENTATION.md to include the step to verify proper exports
- Update CHANGES.md